### PR TITLE
Option to skip assume role

### DIFF
--- a/lib/assume.js
+++ b/lib/assume.js
@@ -20,6 +20,29 @@ class RemoteCredentials {
 
         logger.debug('Requested connection via [%s]', remoteRole);
 
+        // TODO implement this at the config level that specifies account authorization strategy
+        // skip sts assume role if the role is literally called "none" and use local creds instead
+        if (remoteRole === undefined || remoteRole.endsWith("/none")) {
+          return new Promise((resolve, reject) => {
+            logger.debug('Skipping assume role since role name is "none". Using locally configured credentials');
+            AWS.config.getCredentials((err, creds) => {
+              if (err !== undefined) {
+                reject(err)
+              }
+              else {
+                resolve(creds)
+              }
+            })
+          })
+          .then((c) => {
+            return c
+          })
+          .catch((err) => {
+            logger.error('Failed to obtain local AWS credentials', err)
+            return false
+          })
+        }
+
         if (remoteRole in that.creds) {
             if (that.creds[remoteRole].expiration > moment.utc()) {
                 logger.debug('Role [%s] is cached, returning access key [%s], expire at [%s]',


### PR DESCRIPTION
Quick option to skip the STS assume role to support some local debugging options.

Set the following in the `revolver-config.yaml` to skip the role assumption and use locally configured credentials instead.
```
defaults:
  settings:
    revolver_role_name: none
```