### PR TITLE
Make action-runner output more consistent, remove duplicated "pretend" output

### DIFF
--- a/drivers/driverInterface.ts
+++ b/drivers/driverInterface.ts
@@ -79,17 +79,6 @@ export abstract class DriverInterface {
             return null;
           }
 
-          if (this.driverConfig.pretend !== false) {
-            logger.info(
-              'Pretending that %s will execute %s on %s %j',
-              xa.who.name,
-              xa.present,
-              xr.resourceType,
-              allWithAction.map((xxr) => xxr.resourceId),
-            );
-            return this.pretendAction(allWithAction, xa);
-          }
-
           logger.info(
             '%s will execute %s on %s %j',
             xa.who.name,
@@ -97,6 +86,11 @@ export abstract class DriverInterface {
             xr.resourceType,
             allWithAction.map((xxr) => xxr.resourceId),
           );
+
+          if (this.driverConfig.pretend !== false) {
+            return this.pretendAction(allWithAction, xa);
+          }
+
           return (this as any)[xa.what](allWithAction, xa).catch((err: Error) => {
             logger.error(
               'Error in driver %s processing action [%s] on resources %j, stack trace will follow:',


### PR DESCRIPTION
in INFO level, with this patch, actions will be output as messages like "powercycle will execute stop on ec2 [...]"

```
INFO		revolver:whatdev(554096786507)	Driver ec2 is processing actions...
INFO		revolver:whatdev(554096786507)	powercycle will execute stop on ec2 ["i-0b230a154fd0b6481","i-0c41a8c72a37ec6c1"]
INFO		revolver:whatdev(554096786507)	powercycle will execute set tags [{"Key":"ReasonSchedule","Value":"Availability 0x7"}] on ec2 ["i-0b230a154fd0b6481","i-0c41a8c72a37ec6c1"]
INFO		revolver:whatdev(554096786507)	Driver ebs is processing actions...
INFO		revolver:whatdev(554096786507)	Driver snapshot is processing actions...
INFO		revolver:whatdev(554096786507)	Driver rdsInstance is processing actions...
INFO		revolver:whatdev(554096786507)	Driver rdsCluster is processing actions...
```


https://github.com/Innablr/revolver/issues/110
