### PR TITLE
Add action audit logging options

### DIFF
--- a/actions/actions.ts
+++ b/actions/actions.ts
@@ -55,6 +55,7 @@ export class SetTagAction extends RevolverActionWithTags {
 
   constructor(who: RevolverPlugin, tag: string, value: string) {
     super(who, 'setTag');
+    this.reason = `${tag}:${value}`
     this.tags = [
       {
         Key: tag,
@@ -86,6 +87,7 @@ export class UnsetTagAction extends RevolverActionWithTags {
 
   constructor(who: RevolverPlugin, tag: string) {
     super(who, 'unsetTag');
+    this.reason = tag;
     this.tags = [
       {
         Key: tag,
@@ -115,18 +117,20 @@ export class UnsetTagAction extends RevolverActionWithTags {
 export class StopAction extends RevolverAction {
   public changesState: boolean;
 
-  constructor(who: RevolverPlugin) {
+  constructor(who: RevolverPlugin, reason: string) {
     super(who, 'stop');
     this.changesState = true;
+    this.reason = reason;
   }
 }
 
 export class StartAction extends RevolverAction {
   public changesState: boolean;
 
-  constructor(who: RevolverPlugin) {
+  constructor(who: RevolverPlugin, reason: string) {
     super(who, 'start');
     this.changesState = true;
+    this.reason = reason;
   }
 }
 

--- a/actions/audit.ts
+++ b/actions/audit.ts
@@ -1,0 +1,62 @@
+import { DateTime } from 'luxon';
+import { promises as fs } from 'node:fs';
+
+export interface ActionAuditEntry {
+  time: DateTime;
+  plugin: string;
+  driver: string;
+  resourceType: string;
+  resourceId: string;
+  status: string;
+  action: string;
+  reason: string;
+}
+
+abstract class ActionAuditLog {
+  protected readonly entries: ActionAuditEntry[];
+  protected constructor(entries: ActionAuditEntry[]) {
+    this.entries = entries;
+  }
+
+  abstract process(): void;
+}
+
+export class ActionAuditLogCSV extends ActionAuditLog {
+  private readonly outputFile: string;
+  private readonly append: boolean;
+  constructor(entries: ActionAuditEntry[], outputFile: string, append: boolean) {
+    super(entries);
+    this.outputFile = outputFile;
+    this.append = append;
+  }
+
+  process() {
+    let mode = 'w';
+    if (this.append) mode = 'a';
+    fs.open(this.outputFile, mode).then(async (f) => {
+      if (!this.append) {
+        await f.write(`time,plugin,driver,resourceType,resourceId,status,action,reason\n`);
+      }
+      for (const e of this.entries) {
+        const reason = `"${e.reason.replaceAll('"', '""')}"`;
+        const line = `${e.time},${e.plugin},${e.driver},${e.resourceType},${e.resourceId},${e.status},${e.action},${reason}\n`;
+        await f.write(line);
+      }
+    });
+  }
+}
+
+export class ActionAuditLogConsole extends ActionAuditLog {
+  constructor(entries: ActionAuditEntry[]) {
+    super(entries);
+  }
+
+  process() {
+    console.log(`${'PLUGIN'.padEnd(20)}${'DRIVER'.padEnd(25)}${'TYPE'.padEnd(5)}${'ID'.padEnd(40)}${'STATUS'.padEnd(10)}${'ACTION'.padEnd(10)}${'REASON'}`)
+    for (const e of this.entries) {
+      const reason = `"${e.reason.replaceAll('"', '""')}"`;
+      const line = `${e.plugin.padEnd(20)}${e.driver.padEnd(25)}${e.resourceType.padEnd(5)}${e.resourceId.padEnd(40)}${e.status.padEnd(10)}${e.action.padEnd(10)}${reason}`;
+      console.log(line);
+    }
+  }
+}

--- a/actions/audit.ts
+++ b/actions/audit.ts
@@ -35,11 +35,11 @@ export class ActionAuditLogCSV extends ActionAuditLog {
     if (this.append) mode = 'a';
     fs.open(this.outputFile, mode).then(async (f) => {
       if (!this.append) {
-        await f.write(`time,plugin,driver,resourceType,resourceId,status,action,reason\n`);
+        await f.write(`time,plugin,driver,resourceType,resourceId,action,status,reason\n`);
       }
       for (const e of this.entries) {
         const reason = `"${e.reason.replaceAll('"', '""')}"`;
-        const line = `${e.time},${e.plugin},${e.driver},${e.resourceType},${e.resourceId},${e.status},${e.action},${reason}\n`;
+        const line = `${e.time},${e.plugin},${e.driver},${e.resourceType},${e.resourceId},${e.action},${e.status},${reason}\n`;
         await f.write(line);
       }
     });
@@ -52,10 +52,10 @@ export class ActionAuditLogConsole extends ActionAuditLog {
   }
 
   process() {
-    console.log(`${'PLUGIN'.padEnd(20)}${'DRIVER'.padEnd(25)}${'TYPE'.padEnd(5)}${'ID'.padEnd(40)}${'STATUS'.padEnd(10)}${'ACTION'.padEnd(10)}${'REASON'}`)
+    console.log(`${'PLUGIN'.padEnd(20)}${'DRIVER'.padEnd(25)}${'TYPE'.padEnd(5)}${'ID'.padEnd(40)}${'ACTION'.padEnd(10)}${'STATUS'.padEnd(10)}${'REASON'}`)
     for (const e of this.entries) {
       const reason = `"${e.reason.replaceAll('"', '""')}"`;
-      const line = `${e.plugin.padEnd(20)}${e.driver.padEnd(25)}${e.resourceType.padEnd(5)}${e.resourceId.padEnd(40)}${e.status.padEnd(10)}${e.action.padEnd(10)}${reason}`;
+      const line = `${e.plugin.padEnd(20)}${e.driver.padEnd(25)}${e.resourceType.padEnd(5)}${e.resourceId.padEnd(40)}${e.action.padEnd(10)}${e.status.padEnd(10)}${reason}`;
       console.log(line);
     }
   }

--- a/drivers/driverInterface.ts
+++ b/drivers/driverInterface.ts
@@ -52,7 +52,7 @@ export abstract class DriverInterface {
   }
 
   private appendAuditLog(xa: RevolverAction, allWithAction: ToolingInterface[], status: string): void {
-    for(const a of allWithAction) {
+    for (const a of allWithAction) {
       const auditResType = a.awsResourceType !== undefined ? a.awsResourceType : '';
       let auditReason = xa.reason;
       if (auditReason === undefined) auditReason = '';

--- a/lib/config-schema.ts
+++ b/lib/config-schema.ts
@@ -9,6 +9,13 @@ const Settings = z.object({
     organizationRoleName: z.string(),
     revolverRoleName: z.string(),
     saveResources: z.string(),
+    audit: z.object({
+        console: z.boolean().optional(),
+        csv: z.object({
+            file: z.string(),
+            append: z.boolean().default(false),
+        }).optional()
+    })
 });
 
 export default z.object({

--- a/lib/config-schema.ts
+++ b/lib/config-schema.ts
@@ -15,7 +15,7 @@ const Settings = z.object({
             file: z.string(),
             append: z.boolean().default(false),
         }).optional()
-    })
+    }).optional()
 });
 
 export default z.object({

--- a/plugins/powercycle.ts
+++ b/plugins/powercycle.ts
@@ -54,14 +54,14 @@ export default class PowerCyclePlugin extends RevolverPlugin {
         break;
       case 'START':
         logger.debug(`Resource should be started: ${reason}`);
-        resource.addAction(new StartAction(this));
+        resource.addAction(new StartAction(this, reason));
         if (resource.resourceState !== 'running') {
           resource.addAction(new SetTagAction(this, this.reasonTagName, reason));
         }
         break;
       case 'STOP':
         logger.debug(`Resource should be stopped: ${reason}`);
-        resource.addAction(new StopAction(this));
+        resource.addAction(new StopAction(this, reason));
         if (resource.resourceState === 'running') {
           resource.addAction(new SetTagAction(this, this.reasonTagName, reason));
         }

--- a/plugins/validateTags.ts
+++ b/plugins/validateTags.ts
@@ -31,7 +31,7 @@ export default class ValidateTagsPlugin extends RevolverPlugin {
           break;
         case 'stop':
           if (utcTimeNow.diff(resource.launchTimeUtc, 'minutes') > Duration.fromObject({ minutes: 30 })) {
-            resource.addAction(new StopAction(this));
+            resource.addAction(new StopAction(this, `${resource.resourceType} ${resource.resourceId} tag ${tag} is missing`));
           } else {
             resource.addAction(
               new NoopAction(

--- a/revolver-config-example.yaml
+++ b/revolver-config-example.yaml
@@ -8,7 +8,7 @@ defaults:
     revolverRoleName: ssPowerCycle
     saveResources: resources.json
     audit:
-      console:
+      console: true
       csv:
         file: 'audit.csv'
         append: true

--- a/revolver-config-example.yaml
+++ b/revolver-config-example.yaml
@@ -7,6 +7,11 @@ defaults:
     organizationRoleName: AWSOrganizationsReadOnly
     revolverRoleName: ssPowerCycle
     saveResources: resources.json
+    audit:
+      console:
+      csv:
+        file: 'audit.csv'
+        append: true
 
   drivers:
     - name: ec2


### PR DESCRIPTION
Config options to print out actions that were performed in more table like formats.

relates to: https://github.com/Innablr/revolver/issues/110

Currently supports raw `console` and `csv`
```
defaults:
  settings:
    audit:
      console:
      csv:
        file: 'audit.csv'
        append: true
```