### PR TITLE
Add account ID to audit log

### DIFF
--- a/actions/audit.ts
+++ b/actions/audit.ts
@@ -3,6 +3,7 @@ import { promises as fs } from 'node:fs';
 
 export interface ActionAuditEntry {
   time: DateTime;
+  accountId: string;
   plugin: string;
   driver: string;
   resourceType: string;
@@ -35,11 +36,11 @@ export class ActionAuditLogCSV extends ActionAuditLog {
     if (this.append) mode = 'a';
     fs.open(this.outputFile, mode).then(async (f) => {
       if (!this.append) {
-        await f.write(`time,plugin,driver,resourceType,resourceId,action,status,reason\n`);
+        await f.write(`time,accountId,plugin,driver,resourceType,resourceId,action,status,reason\n`);
       }
       for (const e of this.entries) {
         const reason = `"${e.reason.replaceAll('"', '""')}"`;
-        const line = `${e.time},${e.plugin},${e.driver},${e.resourceType},${e.resourceId},${e.action},${e.status},${reason}\n`;
+        const line = `${e.time},${e.accountId},${e.plugin},${e.driver},${e.resourceType},${e.resourceId},${e.action},${e.status},${reason}\n`;
         await f.write(line);
       }
     });
@@ -52,10 +53,9 @@ export class ActionAuditLogConsole extends ActionAuditLog {
   }
 
   process() {
-    console.log(`${'PLUGIN'.padEnd(20)}${'DRIVER'.padEnd(25)}${'TYPE'.padEnd(5)}${'ID'.padEnd(40)}${'ACTION'.padEnd(10)}${'STATUS'.padEnd(10)}${'REASON'}`)
+    console.log(`${'ACCOUNT_ID'.padEnd(16)}${'PLUGIN'.padEnd(20)}${'DRIVER'.padEnd(25)}${'TYPE'.padEnd(5)}${'ID'.padEnd(40)}${'ACTION'.padEnd(10)}${'STATUS'.padEnd(10)}${'REASON'}`)
     for (const e of this.entries) {
-      const reason = `"${e.reason.replaceAll('"', '""')}"`;
-      const line = `${e.plugin.padEnd(20)}${e.driver.padEnd(25)}${e.resourceType.padEnd(5)}${e.resourceId.padEnd(40)}${e.action.padEnd(10)}${e.status.padEnd(10)}${reason}`;
+      const line = `${e.accountId.padEnd(16)}${e.plugin.padEnd(20)}${e.driver.padEnd(25)}${e.resourceType.padEnd(5)}${e.resourceId.padEnd(40)}${e.action.padEnd(10)}${e.status.padEnd(10)}${e.reason}`;
       console.log(line);
     }
   }

--- a/drivers/driverInterface.ts
+++ b/drivers/driverInterface.ts
@@ -53,17 +53,15 @@ export abstract class DriverInterface {
 
   private appendAuditLog(xa: RevolverAction, allWithAction: ToolingInterface[], status: string): void {
     for (const a of allWithAction) {
-      const auditResType = a.awsResourceType !== undefined ? a.awsResourceType : '';
-      let auditReason = xa.reason;
-      if (auditReason === undefined) auditReason = '';
       this.actionAuditLog.push({
+        accountId: a.accountId || '',
         time: DateTime.now(),
         plugin: xa.who.name,
         driver: this.name,
-        resourceType: auditResType,
+        resourceType: a.awsResourceType || '',
         resourceId: a.resourceId,
         action: xa.what,
-        reason: auditReason,
+        reason: xa.reason || '',
         status: status,
       });
     }


### PR DESCRIPTION
Adds Account ID to the audit log for csv and console.

Adding account name will require another PR to globally expose the config to lookup the revolver name based on account ID.