### PR TITLE
Shorten the parser reason timestamp

### DIFF
--- a/plugins/parsers/strict.ts
+++ b/plugins/parsers/strict.ts
@@ -205,7 +205,7 @@ function startOrStop(tag: string, timeNow: DateTime) {
   }
 
   if (t.start.isSet) {
-    const r = `It's now ${timeNow.toFormat('ccc HH:MM Z')}}, resource starts at ${t.start.time} ${t.days ? t.days : 'all week'}`;
+    const r = `It's now ${timeNow.toFormat('ccc HH:MM Z')}, resource starts at ${t.start.time} ${t.days ? t.days : 'all week'}`;
     if (t.dayIn(timeNow)) {
       if (t.start.timePast(timeNow) && !t.start.timePast(timeNow.minus({ minutes: 15 }))) {
         return ['START', r];
@@ -215,7 +215,7 @@ function startOrStop(tag: string, timeNow: DateTime) {
   }
 
   if (t.stop.isSet) {
-    const r = `It's now ${timeNow.toFormat('ccc HH:MM Z')}}, resource stops at ${t.stop.time} ${t.days ? t.days : 'all week'}`;
+    const r = `It's now ${timeNow.toFormat('ccc HH:MM Z')}, resource stops at ${t.stop.time} ${t.days ? t.days : 'all week'}`;
     if (t.dayIn(timeNow)) {
       if (t.stop.timePast(timeNow) && !t.stop.timePast(timeNow.minus({ minutes: 15 }))) {
         return ['STOP', r];

--- a/plugins/parsers/strict.ts
+++ b/plugins/parsers/strict.ts
@@ -194,7 +194,8 @@ function startOrStop(tag: string, timeNow: DateTime) {
   }
 
   if (t.isWindow) {
-    const r = `It's ${timeNow}, availability is from ${t.start.time} till ${t.stop.time} ${
+    //  Format is 'Wed 15:02 +11'
+    const r = `It's ${timeNow.toFormat('ccc HH:MM Z')}, availability is from ${t.start.time} till ${t.stop.time} ${
       t.days ? t.days : 'all week'
     }`;
     if (t.timeIn(timeNow) && t.dayIn(timeNow)) {

--- a/plugins/parsers/strict.ts
+++ b/plugins/parsers/strict.ts
@@ -205,7 +205,7 @@ function startOrStop(tag: string, timeNow: DateTime) {
   }
 
   if (t.start.isSet) {
-    const r = `It's now ${timeNow}, resource starts at ${t.start.time} ${t.days ? t.days : 'all week'}`;
+    const r = `It's now ${timeNow.toFormat('ccc HH:MM Z')}}, resource starts at ${t.start.time} ${t.days ? t.days : 'all week'}`;
     if (t.dayIn(timeNow)) {
       if (t.start.timePast(timeNow) && !t.start.timePast(timeNow.minus({ minutes: 15 }))) {
         return ['START', r];
@@ -215,7 +215,7 @@ function startOrStop(tag: string, timeNow: DateTime) {
   }
 
   if (t.stop.isSet) {
-    const r = `It's now ${timeNow}, resource stops at ${t.stop.time} ${t.days ? t.days : 'all week'}`;
+    const r = `It's now ${timeNow.toFormat('ccc HH:MM Z')}}, resource stops at ${t.stop.time} ${t.days ? t.days : 'all week'}`;
     if (t.dayIn(timeNow)) {
       if (t.stop.timePast(timeNow) && !t.stop.timePast(timeNow.minus({ minutes: 15 }))) {
         return ['STOP', r];

--- a/plugins/parsers/strict.ts
+++ b/plugins/parsers/strict.ts
@@ -1,6 +1,7 @@
 import { DateTime, Interval } from 'luxon';
 
 const zeroPad = (num:number, places:number) => String(num).padStart(places, '0')
+export const reasonDateFormat = 'ccc HH:MM Z';
 
 class ParsedComponent {
   private timeHourLiteral: string | null = null;
@@ -195,7 +196,7 @@ function startOrStop(tag: string, timeNow: DateTime) {
 
   if (t.isWindow) {
     //  Format is 'Wed 15:02 +11'
-    const r = `It's ${timeNow.toFormat('ccc HH:MM Z')}, availability is from ${t.start.time} till ${t.stop.time} ${
+    const r = `It's ${timeNow.toFormat(reasonDateFormat)}, availability is from ${t.start.time} till ${t.stop.time} ${
       t.days ? t.days : 'all week'
     }`;
     if (t.timeIn(timeNow) && t.dayIn(timeNow)) {
@@ -205,7 +206,7 @@ function startOrStop(tag: string, timeNow: DateTime) {
   }
 
   if (t.start.isSet) {
-    const r = `It's now ${timeNow.toFormat('ccc HH:MM Z')}, resource starts at ${t.start.time} ${t.days ? t.days : 'all week'}`;
+    const r = `It's now ${timeNow.toFormat(reasonDateFormat)}, resource starts at ${t.start.time} ${t.days ? t.days : 'all week'}`;
     if (t.dayIn(timeNow)) {
       if (t.start.timePast(timeNow) && !t.start.timePast(timeNow.minus({ minutes: 15 }))) {
         return ['START', r];
@@ -215,7 +216,7 @@ function startOrStop(tag: string, timeNow: DateTime) {
   }
 
   if (t.stop.isSet) {
-    const r = `It's now ${timeNow.toFormat('ccc HH:MM Z')}, resource stops at ${t.stop.time} ${t.days ? t.days : 'all week'}`;
+    const r = `It's now ${timeNow.toFormat(reasonDateFormat)}, resource stops at ${t.stop.time} ${t.days ? t.days : 'all week'}`;
     if (t.dayIn(timeNow)) {
       if (t.stop.timePast(timeNow) && !t.stop.timePast(timeNow.minus({ minutes: 15 }))) {
         return ['STOP', r];

--- a/test/parsers/parserStrict/startStopBarriers.spec.ts
+++ b/test/parsers/parserStrict/startStopBarriers.spec.ts
@@ -48,21 +48,21 @@ describe('Strict parser handles start/stop barriers', async function () {
       it(`not start at ${startBarriers[c]}`, function () {
         const [action, reason] = strictParser(tag, startBarriers[c]);
         expect(action).to.equal('NOOP');
-        expect(reason).to.equal(`It's now ${startBarriers[c]}, resource starts at 6:30 all week`);
+        expect(reason).to.equal(`It's now ${startBarriers[c].toFormat('ccc HH:MM Z')}, resource starts at 6:30 all week`);
       });
     });
     ['monday631', 'monday644', 'monday645'].forEach(function (c) {
       it(`start at ${startBarriers[c]}`, function () {
         const [action, reason] = strictParser(tag, startBarriers[c]);
         expect(action).to.equal('START');
-        expect(reason).to.equal(`It's now ${startBarriers[c]}, resource starts at 6:30 all week`);
+        expect(reason).to.equal(`It's now ${startBarriers[c].toFormat('ccc HH:MM Z')}, resource starts at 6:30 all week`);
       });
     });
     ['monday646'].forEach(function (c) {
       it(`not start at ${startBarriers[c]}`, function () {
         const [action, reason] = strictParser(tag, startBarriers[c]);
         expect(action).to.equal('NOOP');
-        expect(reason).to.equal(`It's now ${startBarriers[c]}, resource starts at 6:30 all week`);
+        expect(reason).to.equal(`It's now ${startBarriers[c].toFormat('ccc HH:MM Z')}, resource starts at 6:30 all week`);
       });
     });
   });
@@ -72,21 +72,21 @@ describe('Strict parser handles start/stop barriers', async function () {
       it(`not stop at ${stopBarriers[c]}`, function () {
         const [action, reason] = strictParser(tag, stopBarriers[c]);
         expect(action).to.equal('NOOP');
-        expect(reason).to.equal(`It's now ${stopBarriers[c]}, resource stops at 17:30 all week`);
+        expect(reason).to.equal(`It's now ${stopBarriers[c].toFormat('ccc HH:MM Z')}, resource stops at 17:30 all week`);
       });
     });
     ['monday1731', 'monday1744', 'monday1745'].forEach(function (c) {
       it(`stop at ${stopBarriers[c]}`, function () {
         const [action, reason] = strictParser(tag, stopBarriers[c]);
         expect(action).to.equal('STOP');
-        expect(reason).to.equal(`It's now ${stopBarriers[c]}, resource stops at 17:30 all week`);
+        expect(reason).to.equal(`It's now ${stopBarriers[c].toFormat('ccc HH:MM Z')}, resource stops at 17:30 all week`);
       });
     });
     ['monday1746'].forEach(function (c) {
       it(`not stop at ${stopBarriers[c]}`, function () {
         const [action, reason] = strictParser(tag, stopBarriers[c]);
         expect(action).to.equal('NOOP');
-        expect(reason).to.equal(`It's now ${stopBarriers[c]}, resource stops at 17:30 all week`);
+        expect(reason).to.equal(`It's now ${stopBarriers[c].toFormat('ccc HH:MM Z')}, resource stops at 17:30 all week`);
       });
     });
   });
@@ -96,14 +96,14 @@ describe('Strict parser handles start/stop barriers', async function () {
       it(`start at ${startBarriersWithDays[c]}`, function () {
         const [action, reason] = strictParser(tag, startBarriersWithDays[c]);
         expect(action).to.equal('START');
-        expect(reason).to.equal(`It's now ${startBarriersWithDays[c]}, resource starts at 6:30 mon-fri`);
+        expect(reason).to.equal(`It's now ${startBarriersWithDays[c].toFormat('ccc HH:MM Z')}, resource starts at 6:30 mon-fri`);
       });
     });
     ['saturday', 'sunday'].forEach(function (c) {
       it(`not start at ${startBarriersWithDays[c]}`, function () {
         const [action, reason] = strictParser(tag, startBarriersWithDays[c]);
         expect(action).to.equal('NOOP');
-        expect(reason).to.equal(`It's now ${startBarriersWithDays[c]}, resource starts at 6:30 mon-fri`);
+        expect(reason).to.equal(`It's now ${startBarriersWithDays[c].toFormat('ccc HH:MM Z')}, resource starts at 6:30 mon-fri`);
       });
     });
   });
@@ -113,21 +113,21 @@ describe('Strict parser handles start/stop barriers', async function () {
       it(`start at ${startBarriersWithDays[c]}`, function () {
         const [action, reason] = strictParser(tag, startBarriersWithDays[c]);
         expect(action).to.equal('START');
-        expect(reason).to.equal(`It's now ${startBarriersWithDays[c]}, resource starts at 6:30 fri-tue`);
+        expect(reason).to.equal(`It's now ${startBarriersWithDays[c].toFormat('ccc HH:MM Z')}, resource starts at 6:30 fri-tue`);
       });
     });
     ['wednesday', 'thursday'].forEach(function (c) {
       it(`not start at ${startBarriersWithDays[c]}`, function () {
         const [action, reason] = strictParser(tag, startBarriersWithDays[c]);
         expect(action).to.equal('NOOP');
-        expect(reason).to.equal(`It's now ${startBarriersWithDays[c]}, resource starts at 6:30 fri-tue`);
+        expect(reason).to.equal(`It's now ${startBarriersWithDays[c].toFormat('ccc HH:MM Z')}, resource starts at 6:30 fri-tue`);
       });
     });
     ['friday', 'saturday', 'sunday'].forEach(function (c) {
       it(`start at ${startBarriersWithDays[c]}`, function () {
         const [action, reason] = strictParser(tag, startBarriersWithDays[c]);
         expect(action).to.equal('START');
-        expect(reason).to.equal(`It's now ${startBarriersWithDays[c]}, resource starts at 6:30 fri-tue`);
+        expect(reason).to.equal(`It's now ${startBarriersWithDays[c].toFormat('ccc HH:MM Z')}, resource starts at 6:30 fri-tue`);
       });
     });
   });
@@ -137,14 +137,14 @@ describe('Strict parser handles start/stop barriers', async function () {
       it(`stop at ${stopBarriersWithDays[c]}`, function () {
         const [action, reason] = strictParser(tag, stopBarriersWithDays[c]);
         expect(action).to.equal('STOP');
-        expect(reason).to.equal(`It's now ${stopBarriersWithDays[c]}, resource stops at 17:30 mon-fri`);
+        expect(reason).to.equal(`It's now ${stopBarriersWithDays[c].toFormat('ccc HH:MM Z')}, resource stops at 17:30 mon-fri`);
       });
     });
     ['saturday', 'sunday'].forEach(function (c) {
       it(`not stop at ${stopBarriersWithDays[c]}`, function () {
         const [action, reason] = strictParser(tag, stopBarriersWithDays[c]);
         expect(action).to.equal('NOOP');
-        expect(reason).to.equal(`It's now ${stopBarriersWithDays[c]}, resource stops at 17:30 mon-fri`);
+        expect(reason).to.equal(`It's now ${stopBarriersWithDays[c].toFormat('ccc HH:MM Z')}, resource stops at 17:30 mon-fri`);
       });
     });
   });
@@ -154,21 +154,21 @@ describe('Strict parser handles start/stop barriers', async function () {
       it(`stop at ${stopBarriersWithDays[c]}`, function () {
         const [action, reason] = strictParser(tag, stopBarriersWithDays[c]);
         expect(action).to.equal('STOP');
-        expect(reason).to.equal(`It's now ${stopBarriersWithDays[c]}, resource stops at 17:30 thu-mon`);
+        expect(reason).to.equal(`It's now ${stopBarriersWithDays[c].toFormat('ccc HH:MM Z')}, resource stops at 17:30 thu-mon`);
       });
     });
     ['tuesday', 'wednesday'].forEach(function (c) {
       it(`not stop at ${stopBarriersWithDays[c]}`, function () {
         const [action, reason] = strictParser(tag, stopBarriersWithDays[c]);
         expect(action).to.equal('NOOP');
-        expect(reason).to.equal(`It's now ${stopBarriersWithDays[c]}, resource stops at 17:30 thu-mon`);
+        expect(reason).to.equal(`It's now ${stopBarriersWithDays[c].toFormat('ccc HH:MM Z')}, resource stops at 17:30 thu-mon`);
       });
     });
     ['thursday', 'friday', 'saturday', 'sunday'].forEach(function (c) {
       it(`stop at ${stopBarriersWithDays[c]}`, function () {
         const [action, reason] = strictParser(tag, stopBarriersWithDays[c]);
         expect(action).to.equal('STOP');
-        expect(reason).to.equal(`It's now ${stopBarriersWithDays[c]}, resource stops at 17:30 thu-mon`);
+        expect(reason).to.equal(`It's now ${stopBarriersWithDays[c].toFormat('ccc HH:MM Z')}, resource stops at 17:30 thu-mon`);
       });
     });
   });

--- a/test/parsers/parserStrict/startStopBarriers.spec.ts
+++ b/test/parsers/parserStrict/startStopBarriers.spec.ts
@@ -1,6 +1,7 @@
 import getParser from '../../../plugins/parsers';
 import { expect } from 'chai';
 import { DateTime } from 'luxon';
+import { reasonDateFormat } from '../../../plugins/parsers/strict';
 
 const startBarriers: { [key: string]: DateTime } = {
   monday629: DateTime.fromJSDate(new Date('2017-06-05 06:29')),
@@ -48,21 +49,21 @@ describe('Strict parser handles start/stop barriers', async function () {
       it(`not start at ${startBarriers[c]}`, function () {
         const [action, reason] = strictParser(tag, startBarriers[c]);
         expect(action).to.equal('NOOP');
-        expect(reason).to.equal(`It's now ${startBarriers[c].toFormat('ccc HH:MM Z')}, resource starts at 6:30 all week`);
+        expect(reason).to.equal(`It's now ${startBarriers[c].toFormat(reasonDateFormat)}, resource starts at 6:30 all week`);
       });
     });
     ['monday631', 'monday644', 'monday645'].forEach(function (c) {
       it(`start at ${startBarriers[c]}`, function () {
         const [action, reason] = strictParser(tag, startBarriers[c]);
         expect(action).to.equal('START');
-        expect(reason).to.equal(`It's now ${startBarriers[c].toFormat('ccc HH:MM Z')}, resource starts at 6:30 all week`);
+        expect(reason).to.equal(`It's now ${startBarriers[c].toFormat(reasonDateFormat)}, resource starts at 6:30 all week`);
       });
     });
     ['monday646'].forEach(function (c) {
       it(`not start at ${startBarriers[c]}`, function () {
         const [action, reason] = strictParser(tag, startBarriers[c]);
         expect(action).to.equal('NOOP');
-        expect(reason).to.equal(`It's now ${startBarriers[c].toFormat('ccc HH:MM Z')}, resource starts at 6:30 all week`);
+        expect(reason).to.equal(`It's now ${startBarriers[c].toFormat(reasonDateFormat)}, resource starts at 6:30 all week`);
       });
     });
   });
@@ -72,21 +73,21 @@ describe('Strict parser handles start/stop barriers', async function () {
       it(`not stop at ${stopBarriers[c]}`, function () {
         const [action, reason] = strictParser(tag, stopBarriers[c]);
         expect(action).to.equal('NOOP');
-        expect(reason).to.equal(`It's now ${stopBarriers[c].toFormat('ccc HH:MM Z')}, resource stops at 17:30 all week`);
+        expect(reason).to.equal(`It's now ${stopBarriers[c].toFormat(reasonDateFormat)}, resource stops at 17:30 all week`);
       });
     });
     ['monday1731', 'monday1744', 'monday1745'].forEach(function (c) {
       it(`stop at ${stopBarriers[c]}`, function () {
         const [action, reason] = strictParser(tag, stopBarriers[c]);
         expect(action).to.equal('STOP');
-        expect(reason).to.equal(`It's now ${stopBarriers[c].toFormat('ccc HH:MM Z')}, resource stops at 17:30 all week`);
+        expect(reason).to.equal(`It's now ${stopBarriers[c].toFormat(reasonDateFormat)}, resource stops at 17:30 all week`);
       });
     });
     ['monday1746'].forEach(function (c) {
       it(`not stop at ${stopBarriers[c]}`, function () {
         const [action, reason] = strictParser(tag, stopBarriers[c]);
         expect(action).to.equal('NOOP');
-        expect(reason).to.equal(`It's now ${stopBarriers[c].toFormat('ccc HH:MM Z')}, resource stops at 17:30 all week`);
+        expect(reason).to.equal(`It's now ${stopBarriers[c].toFormat(reasonDateFormat)}, resource stops at 17:30 all week`);
       });
     });
   });
@@ -96,14 +97,14 @@ describe('Strict parser handles start/stop barriers', async function () {
       it(`start at ${startBarriersWithDays[c]}`, function () {
         const [action, reason] = strictParser(tag, startBarriersWithDays[c]);
         expect(action).to.equal('START');
-        expect(reason).to.equal(`It's now ${startBarriersWithDays[c].toFormat('ccc HH:MM Z')}, resource starts at 6:30 mon-fri`);
+        expect(reason).to.equal(`It's now ${startBarriersWithDays[c].toFormat(reasonDateFormat)}, resource starts at 6:30 mon-fri`);
       });
     });
     ['saturday', 'sunday'].forEach(function (c) {
       it(`not start at ${startBarriersWithDays[c]}`, function () {
         const [action, reason] = strictParser(tag, startBarriersWithDays[c]);
         expect(action).to.equal('NOOP');
-        expect(reason).to.equal(`It's now ${startBarriersWithDays[c].toFormat('ccc HH:MM Z')}, resource starts at 6:30 mon-fri`);
+        expect(reason).to.equal(`It's now ${startBarriersWithDays[c].toFormat(reasonDateFormat)}, resource starts at 6:30 mon-fri`);
       });
     });
   });
@@ -113,21 +114,21 @@ describe('Strict parser handles start/stop barriers', async function () {
       it(`start at ${startBarriersWithDays[c]}`, function () {
         const [action, reason] = strictParser(tag, startBarriersWithDays[c]);
         expect(action).to.equal('START');
-        expect(reason).to.equal(`It's now ${startBarriersWithDays[c].toFormat('ccc HH:MM Z')}, resource starts at 6:30 fri-tue`);
+        expect(reason).to.equal(`It's now ${startBarriersWithDays[c].toFormat(reasonDateFormat)}, resource starts at 6:30 fri-tue`);
       });
     });
     ['wednesday', 'thursday'].forEach(function (c) {
       it(`not start at ${startBarriersWithDays[c]}`, function () {
         const [action, reason] = strictParser(tag, startBarriersWithDays[c]);
         expect(action).to.equal('NOOP');
-        expect(reason).to.equal(`It's now ${startBarriersWithDays[c].toFormat('ccc HH:MM Z')}, resource starts at 6:30 fri-tue`);
+        expect(reason).to.equal(`It's now ${startBarriersWithDays[c].toFormat(reasonDateFormat)}, resource starts at 6:30 fri-tue`);
       });
     });
     ['friday', 'saturday', 'sunday'].forEach(function (c) {
       it(`start at ${startBarriersWithDays[c]}`, function () {
         const [action, reason] = strictParser(tag, startBarriersWithDays[c]);
         expect(action).to.equal('START');
-        expect(reason).to.equal(`It's now ${startBarriersWithDays[c].toFormat('ccc HH:MM Z')}, resource starts at 6:30 fri-tue`);
+        expect(reason).to.equal(`It's now ${startBarriersWithDays[c].toFormat(reasonDateFormat)}, resource starts at 6:30 fri-tue`);
       });
     });
   });
@@ -137,14 +138,14 @@ describe('Strict parser handles start/stop barriers', async function () {
       it(`stop at ${stopBarriersWithDays[c]}`, function () {
         const [action, reason] = strictParser(tag, stopBarriersWithDays[c]);
         expect(action).to.equal('STOP');
-        expect(reason).to.equal(`It's now ${stopBarriersWithDays[c].toFormat('ccc HH:MM Z')}, resource stops at 17:30 mon-fri`);
+        expect(reason).to.equal(`It's now ${stopBarriersWithDays[c].toFormat(reasonDateFormat)}, resource stops at 17:30 mon-fri`);
       });
     });
     ['saturday', 'sunday'].forEach(function (c) {
       it(`not stop at ${stopBarriersWithDays[c]}`, function () {
         const [action, reason] = strictParser(tag, stopBarriersWithDays[c]);
         expect(action).to.equal('NOOP');
-        expect(reason).to.equal(`It's now ${stopBarriersWithDays[c].toFormat('ccc HH:MM Z')}, resource stops at 17:30 mon-fri`);
+        expect(reason).to.equal(`It's now ${stopBarriersWithDays[c].toFormat(reasonDateFormat)}, resource stops at 17:30 mon-fri`);
       });
     });
   });
@@ -154,21 +155,21 @@ describe('Strict parser handles start/stop barriers', async function () {
       it(`stop at ${stopBarriersWithDays[c]}`, function () {
         const [action, reason] = strictParser(tag, stopBarriersWithDays[c]);
         expect(action).to.equal('STOP');
-        expect(reason).to.equal(`It's now ${stopBarriersWithDays[c].toFormat('ccc HH:MM Z')}, resource stops at 17:30 thu-mon`);
+        expect(reason).to.equal(`It's now ${stopBarriersWithDays[c].toFormat(reasonDateFormat)}, resource stops at 17:30 thu-mon`);
       });
     });
     ['tuesday', 'wednesday'].forEach(function (c) {
       it(`not stop at ${stopBarriersWithDays[c]}`, function () {
         const [action, reason] = strictParser(tag, stopBarriersWithDays[c]);
         expect(action).to.equal('NOOP');
-        expect(reason).to.equal(`It's now ${stopBarriersWithDays[c].toFormat('ccc HH:MM Z')}, resource stops at 17:30 thu-mon`);
+        expect(reason).to.equal(`It's now ${stopBarriersWithDays[c].toFormat(reasonDateFormat)}, resource stops at 17:30 thu-mon`);
       });
     });
     ['thursday', 'friday', 'saturday', 'sunday'].forEach(function (c) {
       it(`stop at ${stopBarriersWithDays[c]}`, function () {
         const [action, reason] = strictParser(tag, stopBarriersWithDays[c]);
         expect(action).to.equal('STOP');
-        expect(reason).to.equal(`It's now ${stopBarriersWithDays[c].toFormat('ccc HH:MM Z')}, resource stops at 17:30 thu-mon`);
+        expect(reason).to.equal(`It's now ${stopBarriersWithDays[c].toFormat(reasonDateFormat)}, resource stops at 17:30 thu-mon`);
       });
     });
   });

--- a/test/parsers/parserStrict/windowAvailability.spec.ts
+++ b/test/parsers/parserStrict/windowAvailability.spec.ts
@@ -63,21 +63,21 @@ describe('Strict parser handles availability windows', async function () {
       it(`stop at ${timePoints[c]}`, function () {
         const [action, reason] = strictParser(tag, timePoints[c]);
         expect(action).to.equal('STOP');
-        expect(reason).to.equal(`It's ${timePoints[c]}, availability is from 6:30 till 17:30 all week`);
+        expect(reason).to.equal(`It's ${timePoints[c].toFormat('ccc HH:MM Z')}, availability is from 6:30 till 17:30 all week`);
       });
     });
     ['monday630', 'monday631', 'monday1330', 'monday1530', 'monday1729'].forEach(function (c) {
       it(`start at ${timePoints[c]}`, function () {
         const [action, reason] = strictParser(tag, timePoints[c]);
         expect(action).to.equal('START');
-        expect(reason).to.equal(`It's ${timePoints[c]}, availability is from 6:30 till 17:30 all week`);
+        expect(reason).to.equal(`It's ${timePoints[c].toFormat('ccc HH:MM Z')}, availability is from 6:30 till 17:30 all week`);
       });
     });
     ['monday1730', 'monday1731', 'monday2130', 'tuesday0000', 'tuesday0100', 'tuesday0400'].forEach(function (c) {
       it(`stop at ${timePoints[c]}`, function () {
         const [action, reason] = strictParser(tag, timePoints[c]);
         expect(action).to.equal('STOP');
-        expect(reason).to.equal(`It's ${timePoints[c]}, availability is from 6:30 till 17:30 all week`);
+        expect(reason).to.equal(`It's ${timePoints[c].toFormat('ccc HH:MM Z')}, availability is from 6:30 till 17:30 all week`);
       });
     });
   });
@@ -87,21 +87,21 @@ describe('Strict parser handles availability windows', async function () {
       it(`start at ${timePoints[c]}`, function () {
         const [action, reason] = strictParser(tag, timePoints[c]);
         expect(action).to.equal('START');
-        expect(reason).to.equal(`It's ${timePoints[c]}, availability is from 17:30 till 6:30 all week`);
+        expect(reason).to.equal(`It's ${timePoints[c].toFormat('ccc HH:MM Z')}, availability is from 17:30 till 6:30 all week`);
       });
     });
     ['monday630', 'monday631', 'monday1330', 'monday1530', 'monday1729'].forEach(function (c) {
       it(`stop at ${timePoints[c]}`, function () {
         const [action, reason] = strictParser(tag, timePoints[c]);
         expect(action).to.equal('STOP');
-        expect(reason).to.equal(`It's ${timePoints[c]}, availability is from 17:30 till 6:30 all week`);
+        expect(reason).to.equal(`It's ${timePoints[c].toFormat('ccc HH:MM Z')}, availability is from 17:30 till 6:30 all week`);
       });
     });
     ['monday1730', 'monday1731', 'monday2130', 'tuesday0000', 'tuesday0100', 'tuesday0400'].forEach(function (c) {
       it(`not start at ${timePoints[c]}`, function () {
         const [action, reason] = strictParser(tag, timePoints[c]);
         expect(action).to.equal('START');
-        expect(reason).to.equal(`It's ${timePoints[c]}, availability is from 17:30 till 6:30 all week`);
+        expect(reason).to.equal(`It's ${timePoints[c].toFormat('ccc HH:MM Z')}, availability is from 17:30 till 6:30 all week`);
       });
     });
   });
@@ -113,7 +113,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekday stop at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('STOP');
-          expect(reason).to.equal(`It's ${timePointsDays[c]}, availability is from 6:30 till 17:30 mon-fri`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 6:30 till 17:30 mon-fri`);
         });
       });
     Object.keys(timePointsDays)
@@ -122,7 +122,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekday start at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('START');
-          expect(reason).to.equal(`It's ${timePointsDays[c]}, availability is from 6:30 till 17:30 mon-fri`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 6:30 till 17:30 mon-fri`);
         });
       });
     Object.keys(timePointsDays)
@@ -131,7 +131,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekday start at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('START');
-          expect(reason).to.equal(`It's ${timePointsDays[c]}, availability is from 6:30 till 17:30 mon-fri`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 6:30 till 17:30 mon-fri`);
         });
       });
     Object.keys(timePointsDays)
@@ -140,7 +140,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekday stop at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('STOP');
-          expect(reason).to.equal(`It's ${timePointsDays[c]}, availability is from 6:30 till 17:30 mon-fri`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 6:30 till 17:30 mon-fri`);
         });
       });
     Object.keys(timePointsDays)
@@ -149,7 +149,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekend stop at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('STOP');
-          expect(reason).to.equal(`It's ${timePointsDays[c]}, availability is from 6:30 till 17:30 mon-fri`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 6:30 till 17:30 mon-fri`);
         });
       });
   });
@@ -161,7 +161,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekday stop at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('STOP');
-          expect(reason).to.equal(`It's ${timePointsDays[c]}, availability is from 6:30 till 17:30 fri-mon`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 6:30 till 17:30 fri-mon`);
         });
       });
     Object.keys(timePointsDays)
@@ -170,7 +170,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekday stop at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('STOP');
-          expect(reason).to.equal(`It's ${timePointsDays[c]}, availability is from 6:30 till 17:30 fri-mon`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 6:30 till 17:30 fri-mon`);
         });
       });
     Object.keys(timePointsDays)
@@ -179,7 +179,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekday stop at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('STOP');
-          expect(reason).to.equal(`It's ${timePointsDays[c]}, availability is from 6:30 till 17:30 fri-mon`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 6:30 till 17:30 fri-mon`);
         });
       });
     Object.keys(timePointsDays)
@@ -188,7 +188,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekday stop at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('STOP');
-          expect(reason).to.equal(`It's ${timePointsDays[c]}, availability is from 6:30 till 17:30 fri-mon`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 6:30 till 17:30 fri-mon`);
         });
       });
     Object.keys(timePointsDays)
@@ -197,7 +197,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekday stop at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('STOP');
-          expect(reason).to.equal(`It's ${timePointsDays[c]}, availability is from 6:30 till 17:30 fri-mon`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 6:30 till 17:30 fri-mon`);
         });
       });
     Object.keys(timePointsDays)
@@ -206,7 +206,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekday stop at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('START');
-          expect(reason).to.equal(`It's ${timePointsDays[c]}, availability is from 6:30 till 17:30 fri-mon`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 6:30 till 17:30 fri-mon`);
         });
       });
     Object.keys(timePointsDays)
@@ -215,7 +215,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekday stop at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('START');
-          expect(reason).to.equal(`It's ${timePointsDays[c]}, availability is from 6:30 till 17:30 fri-mon`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 6:30 till 17:30 fri-mon`);
         });
       });
     Object.keys(timePointsDays)
@@ -224,7 +224,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekday stop at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('STOP');
-          expect(reason).to.equal(`It's ${timePointsDays[c]}, availability is from 6:30 till 17:30 fri-mon`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 6:30 till 17:30 fri-mon`);
         });
       });
   });
@@ -236,7 +236,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekday start at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('START');
-          expect(reason).to.equal(`It's ${timePointsDays[c]}, availability is from 17:30 till 6:30 mon-fri`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 17:30 till 6:30 mon-fri`);
         });
       });
     Object.keys(timePointsDays)
@@ -245,7 +245,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekday stop at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('STOP');
-          expect(reason).to.equal(`It's ${timePointsDays[c]}, availability is from 17:30 till 6:30 mon-fri`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 17:30 till 6:30 mon-fri`);
         });
       });
     Object.keys(timePointsDays)
@@ -254,7 +254,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekday stop at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('STOP');
-          expect(reason).to.equal(`It's ${timePointsDays[c]}, availability is from 17:30 till 6:30 mon-fri`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 17:30 till 6:30 mon-fri`);
         });
       });
     Object.keys(timePointsDays)
@@ -263,14 +263,14 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekday start at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('START');
-          expect(reason).to.equal(`It's ${timePointsDays[c]}, availability is from 17:30 till 6:30 mon-fri`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 17:30 till 6:30 mon-fri`);
         });
       });
     ['saturday100', 'saturday625'].forEach(function (c) {
       it(`weekend start at ${timePointsDays[c]}`, function () {
         const [action, reason] = strictParser(tag, timePointsDays[c]);
         expect(action).to.equal('START');
-        expect(reason).to.equal(`It's ${timePointsDays[c]}, availability is from 17:30 till 6:30 mon-fri`);
+        expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 17:30 till 6:30 mon-fri`);
       });
     });
     ['saturday635', 'saturday1725', 'saturday1735', 'sunday100', 'sunday625', 'sunday635', 'sunday1725'].forEach(
@@ -278,7 +278,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekend stop at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('STOP');
-          expect(reason).to.equal(`It's ${timePointsDays[c]}, availability is from 17:30 till 6:30 mon-fri`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 17:30 till 6:30 mon-fri`);
         });
       },
     );
@@ -286,7 +286,7 @@ describe('Strict parser handles availability windows', async function () {
       it(`weekend start at ${timePointsDays[c]}`, function () {
         const [action, reason] = strictParser(tag, timePointsDays[c]);
         expect(action).to.equal('START');
-        expect(reason).to.equal(`It's ${timePointsDays[c]}, availability is from 17:30 till 6:30 mon-fri`);
+        expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 17:30 till 6:30 mon-fri`);
       });
     });
   });
@@ -296,21 +296,21 @@ describe('Strict parser handles availability windows', async function () {
       it(`weekday start at ${timePointsDays[c]}`, function () {
         const [action, reason] = strictParser(tag, timePointsDays[c]);
         expect(action).to.equal('START');
-        expect(reason).to.equal(`It's ${timePointsDays[c]}, availability is from 17:30 till 6:30 fri-tue`);
+        expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 17:30 till 6:30 fri-tue`);
       });
     });
     ['monday635', 'monday1725', 'tuesday635', 'tuesday1725'].forEach(function (c) {
       it(`weekday stop at ${timePointsDays[c]}`, function () {
         const [action, reason] = strictParser(tag, timePointsDays[c]);
         expect(action).to.equal('STOP');
-        expect(reason).to.equal(`It's ${timePointsDays[c]}, availability is from 17:30 till 6:30 fri-tue`);
+        expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 17:30 till 6:30 fri-tue`);
       });
     });
     ['tuesday2355', 'wednesday100', 'wednesday625'].forEach(function (c) {
       it(`weekend start at ${timePointsDays[c]}`, function () {
         const [action, reason] = strictParser(tag, timePointsDays[c]);
         expect(action).to.equal('START');
-        expect(reason).to.equal(`It's ${timePointsDays[c]}, availability is from 17:30 till 6:30 fri-tue`);
+        expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 17:30 till 6:30 fri-tue`);
       });
     });
     ['wednesday635', 'wednesday1725', 'wednesday1735', 'thursday625', 'thursday635', 'thursday1725'].forEach(
@@ -318,7 +318,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekend stop at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('STOP');
-          expect(reason).to.equal(`It's ${timePointsDays[c]}, availability is from 17:30 till 6:30 fri-tue`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 17:30 till 6:30 fri-tue`);
         });
       },
     );
@@ -326,7 +326,7 @@ describe('Strict parser handles availability windows', async function () {
       it(`weekend start at ${timePointsDays[c]}`, function () {
         const [action, reason] = strictParser(tag, timePointsDays[c]);
         expect(action).to.equal('START');
-        expect(reason).to.equal(`It's ${timePointsDays[c]}, availability is from 17:30 till 6:30 fri-tue`);
+        expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 17:30 till 6:30 fri-tue`);
       });
     });
     Object.keys(timePointsDays)
@@ -335,7 +335,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekday start at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('START');
-          expect(reason).to.equal(`It's ${timePointsDays[c]}, availability is from 17:30 till 6:30 fri-tue`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 17:30 till 6:30 fri-tue`);
         });
       });
     Object.keys(timePointsDays)
@@ -344,7 +344,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekday stop at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('STOP');
-          expect(reason).to.equal(`It's ${timePointsDays[c]}, availability is from 17:30 till 6:30 fri-tue`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 17:30 till 6:30 fri-tue`);
         });
       });
     Object.keys(timePointsDays)
@@ -353,7 +353,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekday stop at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('STOP');
-          expect(reason).to.equal(`It's ${timePointsDays[c]}, availability is from 17:30 till 6:30 fri-tue`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 17:30 till 6:30 fri-tue`);
         });
       });
     Object.keys(timePointsDays)
@@ -362,7 +362,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekday start at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('START');
-          expect(reason).to.equal(`It's ${timePointsDays[c]}, availability is from 17:30 till 6:30 fri-tue`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 17:30 till 6:30 fri-tue`);
         });
       });
   });

--- a/test/parsers/parserStrict/windowAvailability.spec.ts
+++ b/test/parsers/parserStrict/windowAvailability.spec.ts
@@ -1,6 +1,7 @@
 import getParser from '../../../plugins/parsers';
 import { expect } from 'chai';
 import { DateTime } from 'luxon';
+import { reasonDateFormat } from '../../../plugins/parsers/strict';
 
 const timePoints: { [key: string]: DateTime } = {
   monday629: DateTime.fromJSDate(new Date('2017-06-05 06:29')),
@@ -63,21 +64,21 @@ describe('Strict parser handles availability windows', async function () {
       it(`stop at ${timePoints[c]}`, function () {
         const [action, reason] = strictParser(tag, timePoints[c]);
         expect(action).to.equal('STOP');
-        expect(reason).to.equal(`It's ${timePoints[c].toFormat('ccc HH:MM Z')}, availability is from 6:30 till 17:30 all week`);
+        expect(reason).to.equal(`It's ${timePoints[c].toFormat(reasonDateFormat)}, availability is from 6:30 till 17:30 all week`);
       });
     });
     ['monday630', 'monday631', 'monday1330', 'monday1530', 'monday1729'].forEach(function (c) {
       it(`start at ${timePoints[c]}`, function () {
         const [action, reason] = strictParser(tag, timePoints[c]);
         expect(action).to.equal('START');
-        expect(reason).to.equal(`It's ${timePoints[c].toFormat('ccc HH:MM Z')}, availability is from 6:30 till 17:30 all week`);
+        expect(reason).to.equal(`It's ${timePoints[c].toFormat(reasonDateFormat)}, availability is from 6:30 till 17:30 all week`);
       });
     });
     ['monday1730', 'monday1731', 'monday2130', 'tuesday0000', 'tuesday0100', 'tuesday0400'].forEach(function (c) {
       it(`stop at ${timePoints[c]}`, function () {
         const [action, reason] = strictParser(tag, timePoints[c]);
         expect(action).to.equal('STOP');
-        expect(reason).to.equal(`It's ${timePoints[c].toFormat('ccc HH:MM Z')}, availability is from 6:30 till 17:30 all week`);
+        expect(reason).to.equal(`It's ${timePoints[c].toFormat(reasonDateFormat)}, availability is from 6:30 till 17:30 all week`);
       });
     });
   });
@@ -87,21 +88,21 @@ describe('Strict parser handles availability windows', async function () {
       it(`start at ${timePoints[c]}`, function () {
         const [action, reason] = strictParser(tag, timePoints[c]);
         expect(action).to.equal('START');
-        expect(reason).to.equal(`It's ${timePoints[c].toFormat('ccc HH:MM Z')}, availability is from 17:30 till 6:30 all week`);
+        expect(reason).to.equal(`It's ${timePoints[c].toFormat(reasonDateFormat)}, availability is from 17:30 till 6:30 all week`);
       });
     });
     ['monday630', 'monday631', 'monday1330', 'monday1530', 'monday1729'].forEach(function (c) {
       it(`stop at ${timePoints[c]}`, function () {
         const [action, reason] = strictParser(tag, timePoints[c]);
         expect(action).to.equal('STOP');
-        expect(reason).to.equal(`It's ${timePoints[c].toFormat('ccc HH:MM Z')}, availability is from 17:30 till 6:30 all week`);
+        expect(reason).to.equal(`It's ${timePoints[c].toFormat(reasonDateFormat)}, availability is from 17:30 till 6:30 all week`);
       });
     });
     ['monday1730', 'monday1731', 'monday2130', 'tuesday0000', 'tuesday0100', 'tuesday0400'].forEach(function (c) {
       it(`not start at ${timePoints[c]}`, function () {
         const [action, reason] = strictParser(tag, timePoints[c]);
         expect(action).to.equal('START');
-        expect(reason).to.equal(`It's ${timePoints[c].toFormat('ccc HH:MM Z')}, availability is from 17:30 till 6:30 all week`);
+        expect(reason).to.equal(`It's ${timePoints[c].toFormat(reasonDateFormat)}, availability is from 17:30 till 6:30 all week`);
       });
     });
   });
@@ -113,7 +114,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekday stop at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('STOP');
-          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 6:30 till 17:30 mon-fri`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat(reasonDateFormat)}, availability is from 6:30 till 17:30 mon-fri`);
         });
       });
     Object.keys(timePointsDays)
@@ -122,7 +123,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekday start at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('START');
-          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 6:30 till 17:30 mon-fri`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat(reasonDateFormat)}, availability is from 6:30 till 17:30 mon-fri`);
         });
       });
     Object.keys(timePointsDays)
@@ -131,7 +132,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekday start at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('START');
-          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 6:30 till 17:30 mon-fri`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat(reasonDateFormat)}, availability is from 6:30 till 17:30 mon-fri`);
         });
       });
     Object.keys(timePointsDays)
@@ -140,7 +141,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekday stop at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('STOP');
-          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 6:30 till 17:30 mon-fri`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat(reasonDateFormat)}, availability is from 6:30 till 17:30 mon-fri`);
         });
       });
     Object.keys(timePointsDays)
@@ -149,7 +150,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekend stop at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('STOP');
-          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 6:30 till 17:30 mon-fri`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat(reasonDateFormat)}, availability is from 6:30 till 17:30 mon-fri`);
         });
       });
   });
@@ -161,7 +162,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekday stop at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('STOP');
-          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 6:30 till 17:30 fri-mon`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat(reasonDateFormat)}, availability is from 6:30 till 17:30 fri-mon`);
         });
       });
     Object.keys(timePointsDays)
@@ -170,7 +171,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekday stop at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('STOP');
-          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 6:30 till 17:30 fri-mon`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat(reasonDateFormat)}, availability is from 6:30 till 17:30 fri-mon`);
         });
       });
     Object.keys(timePointsDays)
@@ -179,7 +180,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekday stop at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('STOP');
-          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 6:30 till 17:30 fri-mon`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat(reasonDateFormat)}, availability is from 6:30 till 17:30 fri-mon`);
         });
       });
     Object.keys(timePointsDays)
@@ -188,7 +189,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekday stop at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('STOP');
-          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 6:30 till 17:30 fri-mon`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat(reasonDateFormat)}, availability is from 6:30 till 17:30 fri-mon`);
         });
       });
     Object.keys(timePointsDays)
@@ -197,7 +198,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekday stop at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('STOP');
-          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 6:30 till 17:30 fri-mon`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat(reasonDateFormat)}, availability is from 6:30 till 17:30 fri-mon`);
         });
       });
     Object.keys(timePointsDays)
@@ -206,7 +207,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekday stop at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('START');
-          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 6:30 till 17:30 fri-mon`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat(reasonDateFormat)}, availability is from 6:30 till 17:30 fri-mon`);
         });
       });
     Object.keys(timePointsDays)
@@ -215,7 +216,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekday stop at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('START');
-          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 6:30 till 17:30 fri-mon`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat(reasonDateFormat)}, availability is from 6:30 till 17:30 fri-mon`);
         });
       });
     Object.keys(timePointsDays)
@@ -224,7 +225,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekday stop at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('STOP');
-          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 6:30 till 17:30 fri-mon`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat(reasonDateFormat)}, availability is from 6:30 till 17:30 fri-mon`);
         });
       });
   });
@@ -236,7 +237,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekday start at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('START');
-          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 17:30 till 6:30 mon-fri`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat(reasonDateFormat)}, availability is from 17:30 till 6:30 mon-fri`);
         });
       });
     Object.keys(timePointsDays)
@@ -245,7 +246,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekday stop at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('STOP');
-          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 17:30 till 6:30 mon-fri`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat(reasonDateFormat)}, availability is from 17:30 till 6:30 mon-fri`);
         });
       });
     Object.keys(timePointsDays)
@@ -254,7 +255,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekday stop at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('STOP');
-          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 17:30 till 6:30 mon-fri`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat(reasonDateFormat)}, availability is from 17:30 till 6:30 mon-fri`);
         });
       });
     Object.keys(timePointsDays)
@@ -263,14 +264,14 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekday start at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('START');
-          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 17:30 till 6:30 mon-fri`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat(reasonDateFormat)}, availability is from 17:30 till 6:30 mon-fri`);
         });
       });
     ['saturday100', 'saturday625'].forEach(function (c) {
       it(`weekend start at ${timePointsDays[c]}`, function () {
         const [action, reason] = strictParser(tag, timePointsDays[c]);
         expect(action).to.equal('START');
-        expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 17:30 till 6:30 mon-fri`);
+        expect(reason).to.equal(`It's ${timePointsDays[c].toFormat(reasonDateFormat)}, availability is from 17:30 till 6:30 mon-fri`);
       });
     });
     ['saturday635', 'saturday1725', 'saturday1735', 'sunday100', 'sunday625', 'sunday635', 'sunday1725'].forEach(
@@ -278,7 +279,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekend stop at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('STOP');
-          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 17:30 till 6:30 mon-fri`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat(reasonDateFormat)}, availability is from 17:30 till 6:30 mon-fri`);
         });
       },
     );
@@ -286,7 +287,7 @@ describe('Strict parser handles availability windows', async function () {
       it(`weekend start at ${timePointsDays[c]}`, function () {
         const [action, reason] = strictParser(tag, timePointsDays[c]);
         expect(action).to.equal('START');
-        expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 17:30 till 6:30 mon-fri`);
+        expect(reason).to.equal(`It's ${timePointsDays[c].toFormat(reasonDateFormat)}, availability is from 17:30 till 6:30 mon-fri`);
       });
     });
   });
@@ -296,21 +297,21 @@ describe('Strict parser handles availability windows', async function () {
       it(`weekday start at ${timePointsDays[c]}`, function () {
         const [action, reason] = strictParser(tag, timePointsDays[c]);
         expect(action).to.equal('START');
-        expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 17:30 till 6:30 fri-tue`);
+        expect(reason).to.equal(`It's ${timePointsDays[c].toFormat(reasonDateFormat)}, availability is from 17:30 till 6:30 fri-tue`);
       });
     });
     ['monday635', 'monday1725', 'tuesday635', 'tuesday1725'].forEach(function (c) {
       it(`weekday stop at ${timePointsDays[c]}`, function () {
         const [action, reason] = strictParser(tag, timePointsDays[c]);
         expect(action).to.equal('STOP');
-        expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 17:30 till 6:30 fri-tue`);
+        expect(reason).to.equal(`It's ${timePointsDays[c].toFormat(reasonDateFormat)}, availability is from 17:30 till 6:30 fri-tue`);
       });
     });
     ['tuesday2355', 'wednesday100', 'wednesday625'].forEach(function (c) {
       it(`weekend start at ${timePointsDays[c]}`, function () {
         const [action, reason] = strictParser(tag, timePointsDays[c]);
         expect(action).to.equal('START');
-        expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 17:30 till 6:30 fri-tue`);
+        expect(reason).to.equal(`It's ${timePointsDays[c].toFormat(reasonDateFormat)}, availability is from 17:30 till 6:30 fri-tue`);
       });
     });
     ['wednesday635', 'wednesday1725', 'wednesday1735', 'thursday625', 'thursday635', 'thursday1725'].forEach(
@@ -318,7 +319,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekend stop at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('STOP');
-          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 17:30 till 6:30 fri-tue`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat(reasonDateFormat)}, availability is from 17:30 till 6:30 fri-tue`);
         });
       },
     );
@@ -326,7 +327,7 @@ describe('Strict parser handles availability windows', async function () {
       it(`weekend start at ${timePointsDays[c]}`, function () {
         const [action, reason] = strictParser(tag, timePointsDays[c]);
         expect(action).to.equal('START');
-        expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 17:30 till 6:30 fri-tue`);
+        expect(reason).to.equal(`It's ${timePointsDays[c].toFormat(reasonDateFormat)}, availability is from 17:30 till 6:30 fri-tue`);
       });
     });
     Object.keys(timePointsDays)
@@ -335,7 +336,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekday start at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('START');
-          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 17:30 till 6:30 fri-tue`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat(reasonDateFormat)}, availability is from 17:30 till 6:30 fri-tue`);
         });
       });
     Object.keys(timePointsDays)
@@ -344,7 +345,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekday stop at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('STOP');
-          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 17:30 till 6:30 fri-tue`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat(reasonDateFormat)}, availability is from 17:30 till 6:30 fri-tue`);
         });
       });
     Object.keys(timePointsDays)
@@ -353,7 +354,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekday stop at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('STOP');
-          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 17:30 till 6:30 fri-tue`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat(reasonDateFormat)}, availability is from 17:30 till 6:30 fri-tue`);
         });
       });
     Object.keys(timePointsDays)
@@ -362,7 +363,7 @@ describe('Strict parser handles availability windows', async function () {
         it(`weekday start at ${timePointsDays[c]}`, function () {
           const [action, reason] = strictParser(tag, timePointsDays[c]);
           expect(action).to.equal('START');
-          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat('ccc HH:MM Z')}, availability is from 17:30 till 6:30 fri-tue`);
+          expect(reason).to.equal(`It's ${timePointsDays[c].toFormat(reasonDateFormat)}, availability is from 17:30 till 6:30 fri-tue`);
         });
       });
   });


### PR DESCRIPTION
Fixes: https://github.com/Innablr/revolver/issues/143
Shortened the timestamp to only include day and time
```
[days vm3]: It's Wed 15:02 +11, availability is from 11:00 till 16:30 mon-fri
```