### PR TITLE
Include actions in the resource-dump output

### DIFF
--- a/drivers/driverInterface.ts
+++ b/drivers/driverInterface.ts
@@ -114,6 +114,11 @@ export abstract class DriverInterface {
             `${xa.who.name} will execute ${xa.present} on ${xr.resourceType} ${allWithAction.map((xxr) => xxr.resourceId)}`,
           );
 
+          // push the list of actions actually run into the resource
+          allWithAction.forEach((xxr) => {
+            (xxr.metadata.actionNames ??= []).push(xa.constructor.name);
+          });
+
           if (this.driverConfig.pretend !== false) {
             this.appendAuditLog(xa, allWithAction, 'pretend');
             return this.pretendAction(allWithAction, xa);

--- a/lib/accountRevolver.ts
+++ b/lib/accountRevolver.ts
@@ -189,10 +189,10 @@ export class AccountRevolver {
     try {
       await this.loadResources();
       await this.runPlugins();
+      await this.runActions();
       if (this.config.settings.resourceLog) {
         await this.logResources();
       }
-      await this.runActions();
       if (this.config.settings.auditLog) {
         await this.logAudit();
       }


### PR DESCRIPTION
Delay the resource dump until after Actions have been run; and include list of non-masked actions in output.

https://github.com/Innablr/revolver/issues/201