### PR TITLE
Remove encoded auth message from errors, limit log output for resource ID lists

### DIFF
--- a/drivers/ec2.ts
+++ b/drivers/ec2.ts
@@ -96,7 +96,7 @@ class Ec2Driver extends DriverInterface {
 
     await Promise.all(
       resourceChunks.map(async function (chunk) {
-        logger.info(`EC2 instances ${chunk.map((xr) => xr.resourceId)} will start`);
+        logger.info(`EC2 instances ${DriverInterface.toLimitedString(chunk)} will start`);
         return ec2.send(
           new StartInstancesCommand({
             InstanceIds: chunk.map((xr) => xr.resourceId),
@@ -152,7 +152,7 @@ class Ec2Driver extends DriverInterface {
 
     await Promise.all(
       resourceChunks.map(async function (chunk) {
-        logger.info(`EC2 instances ${chunk.map((xr) => xr.resourceId)} will stop`);
+        logger.info(`EC2 instances ${DriverInterface.toLimitedString(chunk)} will stop`);
         return ec2.send(
           new StopInstancesCommand({
             InstanceIds: chunk.map((xr) => xr.resourceId),
@@ -165,7 +165,7 @@ class Ec2Driver extends DriverInterface {
   }
 
   noop(resources: InstrumentedEc2[], action: RevolverAction) {
-    this.logger.info(`EC2 instances ${resources.map((xr) => xr.resourceId)} will noop because: ${action.reason}`);
+    this.logger.info(`EC2 instances ${DriverInterface.toLimitedString(resources)} will noop because: ${action.reason}`);
     return Promise.resolve();
   }
 

--- a/test/drivers/driverInterface.spec.ts
+++ b/test/drivers/driverInterface.spec.ts
@@ -1,0 +1,63 @@
+import * as chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { expect } from 'chai';
+import { InstrumentedResource, ToolingInterface } from '../../drivers/instrumentedResource';
+import { DateTime } from 'luxon';
+import { DriverInterface } from '../../drivers/driverInterface';
+
+chai.use(chaiAsPromised);
+
+class RandomInstrumentedResource extends ToolingInterface {
+  get resourceId(): string {
+    return Math.random().toString(36);
+  }
+  get resourceType(): string {
+    throw new Error('Method not implemented.');
+  }
+  get resourceArn(): string {
+    throw new Error('Method not implemented.');
+  }
+  get launchTimeUtc(): DateTime<boolean> {
+    throw new Error('Method not implemented.');
+  }
+  get resourceState(): string {
+    throw new Error('Method not implemented.');
+  }
+  tag(key: string): string | undefined {
+    throw new Error(`Method not implemented. key=${key}`);
+  }
+}
+
+describe('check toLimitedString', function () {
+  class RandomDriver extends DriverInterface {
+    constructor(accountConfig: any, driverConfig: any) {
+      super(accountConfig, driverConfig);
+
+      // RandomDriver.toLimitedString is protected
+
+      for (let len = 0; len <= 3; len++) {
+        const resources = Array(len).fill(new RandomInstrumentedResource(undefined));
+        const s = RandomDriver.toLimitedString(resources);
+        expect(s.split(',').length).to.equal(len ? len : 1);
+        expect(s).to.contain(`(${len})`);
+      }
+
+      const resources20 = Array(20).fill(new RandomInstrumentedResource(undefined));
+      const s20 = RandomDriver.toLimitedString(resources20);
+      expect(s20.split(',').length).is.lessThan(10); // don't be too sensitive about the limit
+      expect(s20).to.contain(`(20)`);
+    }
+
+    collect(): Promise<ToolingInterface[]> {
+      throw new Error('Method not implemented.');
+    }
+    resource(obj: InstrumentedResource): ToolingInterface {
+      throw new Error(`Method not implemented. obj=${obj}`);
+    }
+  }
+
+  const accountConfig = { settings: { name: 'dummy account', accountId: '112233445566' } };
+  const driverConfig = { name: 'dummy driver' };
+  const foo = new RandomDriver(accountConfig, driverConfig);
+  expect(foo).to.be.not.undefined;
+});


### PR DESCRIPTION
Addresses: https://github.com/Innablr/revolver/issues/107

* Removes encoded authorization error message if present. I don't imagine it's particularly useful but we can add an option to dump them if someone needs it.
* Limit log outputs of resource ids to a max of 6, displaying the total length. Previously the log would print all IDs but this will be ridiculous in large accounts. With the introduction of audit logs, this log doesn't need to be comprehensive.
