### PR TITLE
Make metadata a get only property in toolinginterface

### DIFF
--- a/drivers/instrumentedResource.ts
+++ b/drivers/instrumentedResource.ts
@@ -15,11 +15,12 @@ export interface InstrumentedResource {
 export abstract class ToolingInterface implements InstrumentedResource {
   public resource: any;
   public actions: RevolverAction[];
-  public metadata: any;
+  private meta: any;
 
   constructor(awsResource: any) {
     this.resource = awsResource;
     this.actions = [];
+    this.meta = {};
   }
 
   addAction(action: RevolverAction) {
@@ -56,6 +57,11 @@ export abstract class ToolingInterface implements InstrumentedResource {
       resource: this.resource,
       metadata: this.metadata,
     };
+  }
+
+  // Hide set metadata() so plugins can't delete data set by other plugins.
+  get metadata(): any {
+    return this.meta;
   }
 
   get region() {

--- a/plugins/powercycleCentral.ts
+++ b/plugins/powercycleCentral.ts
@@ -97,15 +97,13 @@ export default class PowerCycleCentralPlugin extends RevolverPlugin {
     });
 
     // Add list of all the matched Matchers to the resource metadata
-    resource.metadata = {
-      matches: allMatches.map((matcher: Matcher) => {
-        return {
-          name: matcher.name,
-          schedule: matcher.schedule,
-          priority: matcher.priority,
-        };
-      }),
-    };
+    resource.metadata.matches = allMatches.map((matcher: Matcher) => {
+      return {
+        name: matcher.name,
+        schedule: matcher.schedule,
+        priority: matcher.priority,
+      };
+    });
 
     let highestMatch = allMatches[0]; // undefined if no matches
     const taggedSchedule = resource.tag(this.scheduleTagName);


### PR DESCRIPTION
Fixes: https://github.com/Innablr/revolver/issues/208

Also made metadata a get only field so other plugins can't do `res.metadata = ` and delete anything else set.