### PR TITLE
Add support for invocation via SQS

### DIFF
--- a/drivers/driverInterface.ts
+++ b/drivers/driverInterface.ts
@@ -3,7 +3,7 @@ import { logger, RevolverLogObject } from '../lib/logger';
 import { InstrumentedResource, ToolingInterface } from './instrumentedResource';
 import { RevolverAction } from '../actions/actions';
 import { ActionAuditEntry } from '../actions/audit';
-import { DateTime } from 'luxon';
+import dateTime from '../lib/dateTime';
 
 export abstract class DriverInterface {
   protected accountConfig: any;
@@ -64,7 +64,7 @@ export abstract class DriverInterface {
 
       this.actionAuditLog.push({
         accountId: ti.accountId || '',
-        time: DateTime.now(),
+        time: dateTime.getTime(),
         plugin: plugin,
         driver: this.name,
         resourceType: ti.awsResourceType || '',

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -39,7 +39,7 @@ function flattenZodErrors(ze: ZodError, depth: number): string[] {
 }
 
 export class RevolverConfig {
-  validateConfig(data: string) {
+  static validateConfig(data: string) {
     try {
       const config = ConfigSchema.parse(yaml.load(data));
       logger.debug('Read Revolver config', config);
@@ -54,23 +54,23 @@ export class RevolverConfig {
     }
   }
 
-  async readConfigFromFile(configFile: string) {
+  static async readConfigFromFile(configFile: string) {
     const fullPath = path.resolve(configFile);
     logger.debug(`Fetching config from file ${fullPath}`);
-    return this.validateConfig(await fs.readFile(fullPath, { encoding: 'utf8' }));
+    return RevolverConfig.validateConfig(await fs.readFile(fullPath, { encoding: 'utf8' }));
   }
 
-  async readConfigFromS3(configBucket: string, configKey: string) {
+  static async readConfigFromS3(configBucket: string, configKey: string) {
     const config = getAwsConfig();
     const s3 = new S3Client(config);
     logger.debug(`Fetching config from bucket [${configBucket}] key [${configKey}]`);
 
     const configObject = await s3.send(new GetObjectCommand({ Bucket: configBucket, Key: configKey }));
     logger.debug(`Found S3 object MIME ${configObject.ContentType}`);
-    return this.validateConfig(await configObject.Body!.transformToString());
+    return RevolverConfig.validateConfig(await configObject.Body!.transformToString());
   }
 
-  async getOrganisationsAccounts(creds: any[]) {
+  static async getOrganisationsAccounts(creds: any[]) {
     const orgsRegion = 'us-east-1';
     const allAccounts = await Promise.all(
       creds.map(async (cr: any) => {
@@ -96,7 +96,7 @@ export class RevolverConfig {
     return flatAccounts;
   }
 
-  filterAccountsList(orgsAccountsList: any[], config: any) {
+  static filterAccountsList(orgsAccountsList: any[], config: any) {
     logger.info(`${orgsAccountsList.length} Accounts found on the Organizations listed`);
     logger.info(`${config.accounts.includeList.length} accounts found on include_list`);
     logger.info(`${config.accounts.excludeList.length} accounts found on exclude_list`);

--- a/lib/dateTime.ts
+++ b/lib/dateTime.ts
@@ -9,6 +9,11 @@ class DateTime {
     logger.debug(`Freezing time: ${this.currentTime}`);
   }
 
+  freezeTimeUnix(t: string) {
+    this.currentTime = LuxonDateTime.fromMillis(parseInt(t)).toUTC();
+    logger.debug(`Freezing time: ${this.currentTime}`);
+  }
+
   getTime(tz?: string) {
     if (tz) {
       return this.currentTime.setZone(tz);

--- a/revolver.ts
+++ b/revolver.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-unresolved
-import { EventBridgeEvent, ScheduledEvent, ScheduledHandler } from 'aws-lambda';
+import { EventBridgeEvent, SQSEvent, ScheduledEvent, ScheduledHandler, SQSHandler } from 'aws-lambda';
 import environ from './lib/environ';
 import { AccountRevolver } from './lib/accountRevolver';
 import { logger } from './lib/logger';
@@ -7,8 +7,24 @@ import { RevolverConfig } from './lib/config';
 import dateTime from './lib/dateTime';
 import assume from './lib/assume';
 
+const sqsRecordPrefix = process.env['SQS_RECORD_PREFIX'];
+export const handlerSQS: SQSHandler = async (event: SQSEvent) => {
+  for (const record of event.Records) {
+    if (sqsRecordPrefix) {
+      const recordId = record.messageAttributes[sqsRecordPrefix]?.stringValue;
+      if (recordId) logger.settings.prefix = [recordId];
+    }
+    logger.info(`Starting revolver for record ${record.messageId}`);
+    logger.debug(`Record: ${record}`);
+    const configuration = Buffer.from(record.body).toString('utf-8');
+    const config = RevolverConfig.validateConfig(configuration);
+
+    dateTime.freezeTimeUnix(record.attributes.SentTimestamp);
+    await main(config);
+  }
+};
+
 export const handler: ScheduledHandler = async (event: EventBridgeEvent<'Scheduled Event', ScheduledEvent>) => {
-  const configMethods = new RevolverConfig();
   logger.info('Starting revolver, got event', event);
 
   dateTime.freezeTime(event.time);
@@ -16,12 +32,16 @@ export const handler: ScheduledHandler = async (event: EventBridgeEvent<'Schedul
 
   const config = await (
     environ.configPath
-      ? configMethods.readConfigFromFile(environ.configPath)
-      : configMethods.readConfigFromS3(environ.configBucket!, environ.configKey!)
+      ? RevolverConfig.readConfigFromFile(environ.configPath)
+      : RevolverConfig.readConfigFromS3(environ.configBucket!, environ.configKey!)
   ).catch(function (e: Error) {
     throw new Error(`Unable to parse config object: ${e}. Exiting.`);
   });
 
+  await main(config);
+};
+
+async function main(config: any) {
   // Assume-role on each org (if any listed) and get the list of accounts from it
   const organisationCreds = await Promise.all(
     config.organizations.flatMap((xa: any) => {
@@ -34,10 +54,10 @@ export const handler: ScheduledHandler = async (event: EventBridgeEvent<'Schedul
         });
     }),
   );
-  const orgsAccountsList = await configMethods.getOrganisationsAccounts(organisationCreds);
+  const orgsAccountsList = await RevolverConfig.getOrganisationsAccounts(organisationCreds);
 
   // Filter final accounts list to be processed
-  const filteredAccountsList = await configMethods.filterAccountsList(orgsAccountsList, config);
+  const filteredAccountsList = await RevolverConfig.filterAccountsList(orgsAccountsList, config);
 
   // Try to assume role on the listed accounts and remove from the list if fails
   logger.info('Caching STS credentials...');
@@ -69,4 +89,4 @@ export const handler: ScheduledHandler = async (event: EventBridgeEvent<'Schedul
   await Promise.all(revolvers.map((revolver) => revolver.revolve()));
 
   logger.info('One revolution done.');
-};
+}

--- a/test/config/config.spec.ts
+++ b/test/config/config.spec.ts
@@ -7,14 +7,14 @@ const SAMPLE_CONFIG_1 = path.join(__dirname, 'revolver-config1.yaml');
 
 describe('Validate example config', function () {
   it('Check simple parsing', async function () {
-    const config = await new RevolverConfig().readConfigFromFile(EXAMPLE_CONFIG);
+    const config = await RevolverConfig.readConfigFromFile(EXAMPLE_CONFIG);
     expect(config.defaults.settings.region).to.equal('ap-southeast-2');
   });
 });
 
 describe('Validate test config', function () {
   it('Check simple parsing', async function () {
-    const config = await new RevolverConfig().readConfigFromFile(SAMPLE_CONFIG_1);
+    const config = await RevolverConfig.readConfigFromFile(SAMPLE_CONFIG_1);
 
     // basic settings, defaults
     expect(config.defaults.settings.region).to.equal('ap-southeast-2');


### PR DESCRIPTION
Created a separate handler (`handlerSQS`) to allow revolver invocation with the configuration in the message body.

Set env `SQS_RECORD_PREFIX` to prefix every log entry with some attribute from the SQS record message attributes to help differentiate log entries between what could possibly be many records in one lambda invocation.

Also fixed a bug with audit log that didn't use the global date time value and wouldn't respect the configured time.