### PR TITLE
Update JSON log structure

### DIFF
--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -11,11 +11,84 @@ const logLevels: { [key: string]: number } = {
   fatal: 6,
 };
 
+const logLevelsToConsole: { [key: number]: (...args: any) => any } = {
+  0: console.trace,
+  1: console.trace,
+  2: console.debug,
+  3: console.info,
+  4: console.warn,
+  5: console.error,
+  6: console.error,
+};
+
 export interface RevolverLogObject {
   accountId?: string;
   accountName?: string;
   pluginName?: string;
   driverName?: string;
+}
+
+/**
+ * Restructure JSON logs to behave better in JSON ingestors like cloudwatch.
+ *
+ * Writes JSON logs to the appropriate console.{level} function and converts any configured log prefixes
+ * to object keys if they have a ':' separator. Splits out string messages and object messages to message and data.
+ * @param log
+ */
+function restructureJsonLog(log: any) {
+  if (log == undefined) return;
+  const positionalEntries: string[] = Object.keys(log).filter((k: any) => !isNaN(k));
+
+  const prefixEntries: string[] = positionalEntries.slice(0, logger.settings.prefix.length);
+  const processedPrefix: { [key: string]: boolean } = {};
+  const prefixes: { [key: string]: string } = {};
+
+  // Move prefixed entries to true keys if they have a name
+  prefixEntries.forEach((k) => {
+    const segments = log[k].split(':');
+    if (segments.length > 1) {
+      prefixes[segments[0]] = segments.slice(1).join(':');
+      processedPrefix[k] = true;
+    }
+  });
+
+  const data: any[] = [];
+
+  // create unified message
+  const message: string = positionalEntries
+    .filter((k) => !processedPrefix[k])
+    .filter((k) => {
+      // arrays can be string printed
+      // move objects to data array
+      if (typeof log[k] === 'object' && !Array.isArray(log[k])) {
+        data.push(log[k]);
+        return false;
+      }
+      return true;
+    })
+    .map((k) => log[k])
+    .join(' ');
+
+  positionalEntries.forEach((k: string) => delete log[k]);
+
+  // assemble new object
+  const messageObj: { [key: string]: any } = {
+    message: message,
+  };
+  if (data.length > 0) {
+    messageObj.data = data;
+  }
+
+  // write to log level specific console.log
+  const outputLog = logLevelsToConsole[log[logger.settings.metaProperty].logLevelId] || console.log;
+
+  outputLog(
+    JSON.stringify({
+      ...messageObj,
+      ...prefixes,
+      ...log,
+    }),
+  );
 }
 
 export const logger = new Logger<RevolverLogObject>({
@@ -25,4 +98,9 @@ export const logger = new Logger<RevolverLogObject>({
   prettyLogTimeZone: environ.prettyLogTimeZone,
   minLevel: logLevels[environ.logLevel],
   hideLogPositionForProduction: logLevels[environ.logLevel] > 2,
+  overwrite: {
+    transportJSON: (logObjWithMeta: any) => {
+      restructureJsonLog(logObjWithMeta);
+    },
+  },
 });

--- a/revolver.ts
+++ b/revolver.ts
@@ -7,15 +7,17 @@ import { RevolverConfig } from './lib/config';
 import dateTime from './lib/dateTime';
 import assume from './lib/assume';
 
-const sqsRecordPrefix = process.env['SQS_RECORD_PREFIX'];
+// Specify a SQS message attribute to log out to the console
+const sqsLogAttribute = process.env['SQS_LOG_ATTRIBUTE'];
+
 export const handlerSQS: SQSHandler = async (event: SQSEvent) => {
   for (const record of event.Records) {
-    if (sqsRecordPrefix) {
-      const recordId = record.messageAttributes[sqsRecordPrefix]?.stringValue;
-      if (recordId) logger.settings.prefix = [recordId];
+    if (sqsLogAttribute) {
+      const recordId = record.messageAttributes[sqsLogAttribute]?.stringValue;
+      if (recordId) logger.settings.prefix = [`${sqsLogAttribute}:${recordId}`];
     }
     logger.info(`Starting revolver for record ${record.messageId}`);
-    logger.debug(`Record: ${record}`);
+    logger.trace('Record', record);
     const configuration = Buffer.from(record.body).toString('utf-8');
     const config = RevolverConfig.validateConfig(configuration);
 


### PR DESCRIPTION
Changes the JSON logger to play nicer with cloudwatch
* Uses `console.{trace|debug|info|warn|error}` depending on the log level. This is picked up by cloudwatch.
* Pushes all the string messages to a `message` field rather than having it by "index"
* Extract any prefixes with the format `name:value` as extra fields for use with the SQS_LOG_ATTRIBUTE configuration so SQS handler data can be displayed for each log to differentiate between possibly multiple different revolver runs in the same lambda execution.

#### Old (This shows in cloudwatch as INFO)
```json
{
    "0": "invocationId:5a01120580b5a6ade6ebcd5bad7673fdd6db0113",
    "1": "Freezing time: 2024-03-06T00:17:47.840Z",
    "_meta": {
        "runtime": "Nodejs",
        "runtimeVersion": "v20.11.0",
        "hostname": "169.254.21.225",
        "name": "revolver",
        "date": "2024-03-06T00:17:48.757Z",
        "logLevelId": 2,
        "logLevelName": "DEBUG",
        "path": {
            "fullFilePath": "/var/task/revolver.js:2:2622906",
            "fileName": "revolver.js",
            "fileNameWithLine": "revolver.js:2",
            "fileColumn": "2622906",
            "fileLine": "2",
            "filePath": "/revolver.js",
            "filePathWithLine": "/revolver.js:2",
            "method": "Object.freezeTimeUnix"
        }
    }
}
```
#### New (This shows in cloudwatch as DEBUG)
```json
{
    "message": "Freezing time: 2024-03-06T00:17:47.840Z",
    "invocationId": "5a01120580b5a6ade6ebcd5bad7673fdd6db0113",
    "_meta": {
        "runtime": "Nodejs",
        "runtimeVersion": "v20.11.0",
        "hostname": "169.254.21.225",
        "name": "revolver",
        "date": "2024-03-06T00:17:48.757Z",
        "logLevelId": 2,
        "logLevelName": "DEBUG",
        "path": {
            "fullFilePath": "/var/task/revolver.js:2:2622906",
            "fileName": "revolver.js",
            "fileNameWithLine": "revolver.js:2",
            "fileColumn": "2622906",
            "fileLine": "2",
            "filePath": "/revolver.js",
            "filePathWithLine": "/revolver.js:2",
            "method": "Object.freezeTimeUnix"
        }
    }
}
```