### PR TITLE
Add compression options to SQS input and output

### DIFF
--- a/lib/config-schema.ts
+++ b/lib/config-schema.ts
@@ -67,6 +67,7 @@ const ObjectLogOptions = z.object({
   sqs: z
     .object({
       url: z.string(),
+      compress: z.boolean().default(true),
       attributes: z.record(z.string(), z.string()).optional(),
     })
     .optional(),

--- a/lib/objectLog.ts
+++ b/lib/objectLog.ts
@@ -112,9 +112,10 @@ abstract class AbstractOutputWriter {
 
     if (this.options.sqs?.compress) {
       output = AbstractOutputWriter.compress(output);
+      this.logger.debug(`compressed sqs message size: ${output.length}`);
       attributes['compression'] = {
         DataType: 'String',
-        StringValue: 'gzip',
+        StringValue: 'zlib',
       };
       attributes['encoding'] = {
         DataType: 'String',

--- a/revolver-config-example.yaml
+++ b/revolver-config-example.yaml
@@ -45,6 +45,8 @@ defaults:
         # Option to write output to an SQS queue
         sqs:
           url: "https://sqs.ap-southeast-2.amazonaws.com/123456789012/sqs-queue"
+          # compress messages before sending to queue, defaults to true
+          compress: true
           # attributes can be any key/value string pair and are submitted as message attributes for each SQS message
           attributes:
             costCenter: "1234"

--- a/revolver.ts
+++ b/revolver.ts
@@ -23,7 +23,7 @@ export const handlerSQS: SQSHandler = async (event: SQSEvent) => {
     let body = record.body;
 
     // assumed base64 encoding since this is a text field
-    if (record.messageAttributes['compression']?.stringValue === 'gzip') {
+    if (record.messageAttributes['compression']?.stringValue === 'zlib') {
       body = zlib.inflateSync(Buffer.from(record.body, 'base64')).toString('utf-8');
     }
 


### PR DESCRIPTION
* From sqs handler: Reads the SQS record attributes to determine if the config is compressed
* From the sqs output: Compresses the data before sending to the queue. Uses `compress` option in sqs output. Defaults to enabled

```yaml
json:
  sqs:
    url: 'https://amazon.sqs/queue'
    compress: true
    attributes:
      something: 'value'
```