### PR TITLE
Add region and sizing fields to audit log

### DIFF
--- a/actions/audit.ts
+++ b/actions/audit.ts
@@ -3,6 +3,7 @@ import { DateTime } from 'luxon';
 export interface ActionAuditEntry {
   time: DateTime;
   accountId: string;
+  region: string;
   plugin: string;
   driver: string;
   resourceType: string;
@@ -10,4 +11,5 @@ export interface ActionAuditEntry {
   status: string;
   action: string;
   reason: string;
+  sizing: any;
 }

--- a/drivers/driverInterface.ts
+++ b/drivers/driverInterface.ts
@@ -64,6 +64,7 @@ export abstract class DriverInterface {
 
       this.actionAuditLog.push({
         accountId: ti.accountId || '',
+        region: xa.who.region,
         time: dateTime.getTime(),
         plugin: plugin,
         driver: this.name,
@@ -72,6 +73,7 @@ export abstract class DriverInterface {
         action: action,
         reason: reason,
         status: status,
+        sizing: ti.sizing,
       });
     }
   }

--- a/drivers/ebs.ts
+++ b/drivers/ebs.ts
@@ -50,6 +50,14 @@ class InstrumentedEBS extends ToolingInterface {
   get resourceTags(): { [key: string]: string } {
     return makeResourceTags(this.resource.Tags);
   }
+
+  get sizing(): any {
+    return {
+      Size: this.resource.Size,
+      Iops: this.resource.Iops,
+      VolumeType: this.resource.VolumeType,
+    };
+  }
 }
 
 class EBSDriver extends DriverInterface {

--- a/drivers/ec2.ts
+++ b/drivers/ec2.ts
@@ -73,6 +73,16 @@ class InstrumentedEc2 extends ToolingInterface {
   get resourceTags(): { [key: string]: string } {
     return makeResourceTags(this.resource.Tags);
   }
+
+  get sizing(): any {
+    return {
+      InstanceType: this.resource.InstanceType,
+      Placement: {
+        Tenancy: this.resource.Placement?.Tenancy,
+      },
+      PlatformDetails: this.resource.PlatformDetails,
+    };
+  }
 }
 
 class Ec2Driver extends DriverInterface {

--- a/drivers/ec2.ts
+++ b/drivers/ec2.ts
@@ -81,6 +81,7 @@ class InstrumentedEc2 extends ToolingInterface {
         Tenancy: this.resource.Placement?.Tenancy,
       },
       PlatformDetails: this.resource.PlatformDetails,
+      AutoScalingGroupName: this.resource.AutoScalingGroupName,
     };
   }
 }

--- a/drivers/instrumentedResource.ts
+++ b/drivers/instrumentedResource.ts
@@ -11,6 +11,7 @@ export interface InstrumentedResource {
   resourceTags: { [key: string]: string };
   resource: any;
   metadata: any;
+  sizing: any;
 }
 
 export abstract class ToolingInterface implements InstrumentedResource {
@@ -58,6 +59,7 @@ export abstract class ToolingInterface implements InstrumentedResource {
       resource: this.resource,
       metadata: this.metadata,
       resourceTags: this.resourceTags,
+      sizing: this.sizing,
     };
   }
 
@@ -98,4 +100,6 @@ export abstract class ToolingInterface implements InstrumentedResource {
   abstract tag(key: string): string | undefined;
 
   abstract get resourceTags(): { [key: string]: string };
+
+  abstract get sizing(): any;
 }

--- a/drivers/rdsCluster.ts
+++ b/drivers/rdsCluster.ts
@@ -59,6 +59,27 @@ class InstrumentedRdsCluster extends ToolingInterface {
   get resourceTags(): { [key: string]: string } {
     return makeResourceTags(this.resource.TagList);
   }
+
+  get sizing(): any {
+    return {
+      AllocatedStorage: this.resource.AllocatedStorage,
+      MultiAZ: this.resource.MultiAZ,
+      Engine: this.resource.Engine,
+      EngineVersion: this.resource.EngineVersion,
+      EngineMode: this.resource.EngineMode,
+      DBClusterMembers: this.resource.DBClusterMembers.map((m: any) => {
+        return {
+          AllocatedStorage: m.instanceData.AllocatedStorage,
+          StorageType: m.instanceData.StorageType,
+          DBInstanceClass: m.instanceData.DBInstanceClass,
+          MultiAZ: m.instanceData.MultiAZ,
+          Engine: m.instanceData.Engine,
+          EngineVersion: m.instanceData.EngineVersion,
+          LicenseModel: m.instanceData.LicenseModel,
+        };
+      }),
+    };
+  }
 }
 
 class RdsClusterDriver extends DriverInterface {

--- a/drivers/rdsInstance.ts
+++ b/drivers/rdsInstance.ts
@@ -58,6 +58,18 @@ class InstrumentedRdsInstance extends ToolingInterface {
   get resourceTags(): { [key: string]: string } {
     return makeResourceTags(this.resource.TagList);
   }
+
+  get sizing(): any {
+    return {
+      DBInstanceClass: this.resource.DBInstanceClass,
+      Engine: this.resource.Engine,
+      EngineVersion: this.resource.EngineVersion,
+      AllocatedStorage: this.resource.AllocatedStorage,
+      StorageType: this.resource.StorageType,
+      MultiAZ: this.resource.MultiAZ,
+      LicenseModel: this.resource.LicenseModel,
+    };
+  }
 }
 
 class RdsInstanceDriver extends DriverInterface {

--- a/drivers/redshiftCluster.ts
+++ b/drivers/redshiftCluster.ts
@@ -72,6 +72,15 @@ class InstrumentedRedshiftCluster extends ToolingInterface {
   get resourceTags(): { [key: string]: string } {
     return makeResourceTags(this.resource.Tags);
   }
+
+  get sizing(): any {
+    return {
+      NodeType: this.resource.NodeType,
+      NumberOfNodes: this.resource.NumberOfNodes,
+      MultiAZ: this.resource.MultiAZ,
+      TotalStorageCapacityInMegaBytes: this.resource.TotalStorageCapacityInMegaBytes,
+    };
+  }
 }
 
 class RedshiftClusterDriver extends DriverInterface {

--- a/drivers/redshiftClusterSnapshot.ts
+++ b/drivers/redshiftClusterSnapshot.ts
@@ -53,6 +53,15 @@ class InstrumentedRedshiftClusterSnapshot extends ToolingInterface {
   get resourceTags(): { [key: string]: string } {
     return makeResourceTags(this.resource.Tags);
   }
+
+  get sizing(): any {
+    return {
+      NodeType: this.resource.NodeType,
+      NumberOfNodes: this.resource.NumberOfNodes,
+      ActualIncrementalBackupSizeInMegaBytes: this.resource.ActualIncrementalBackupSizeInMegaBytes,
+      TotalBackupSizeInMegaBytes: this.resource.TotalBackupSizeInMegaBytes,
+    };
+  }
 }
 
 class RedshiftClusterSnapshotDriver extends DriverInterface {

--- a/drivers/snapshot.ts
+++ b/drivers/snapshot.ts
@@ -41,6 +41,13 @@ class InstrumentedSnapshot extends ToolingInterface {
   get resourceTags(): { [key: string]: string } {
     return makeResourceTags(this.resource.Tags);
   }
+
+  get sizing(): any {
+    return {
+      StorageTier: this.resource.StorageTier,
+      VolumeSize: this.resource.VolumeSize,
+    };
+  }
 }
 
 class SnapshotDriver extends DriverInterface {

--- a/plugins/pluginInterface.ts
+++ b/plugins/pluginInterface.ts
@@ -28,6 +28,9 @@ export abstract class RevolverPlugin {
   get name(): string {
     return this.pluginConfig.name;
   }
+  get region(): any {
+    return this.accountConfig.region;
+  }
 
   async initialise(): Promise<RevolverPlugin> {
     this.logger.info(`Plugin ${this.name} is initialising...`);

--- a/test/drivers/driverInterface.spec.ts
+++ b/test/drivers/driverInterface.spec.ts
@@ -29,6 +29,9 @@ class RandomInstrumentedResource extends ToolingInterface {
   get resourceTags(): { [key: string]: string } {
     throw new Error('Method not implemented.');
   }
+  get sizing(): any {
+    throw new Error('Method not implemented.');
+  }
 }
 
 describe('check toLimitedString', function () {

--- a/test/filters/filters.spec.ts
+++ b/test/filters/filters.spec.ts
@@ -42,6 +42,10 @@ class TestingResource extends ToolingInterface {
   get resourceTags(): { [key: string]: string } {
     return makeResourceTags(this.topResource['tags']);
   }
+
+  get sizing(): any {
+    return {};
+  }
 }
 
 const basicEc2 = {

--- a/test/lib/auditLog.spec.ts
+++ b/test/lib/auditLog.spec.ts
@@ -9,6 +9,7 @@ import * as fs from 'fs';
 class FakeActionAuditEntry implements ActionAuditEntry {
   time: DateTime<boolean>;
   accountId: string;
+  region: string;
   plugin: string;
   driver: string;
   resourceType: string;
@@ -16,9 +17,12 @@ class FakeActionAuditEntry implements ActionAuditEntry {
   status: string;
   action: string;
   reason: string;
+  sizing: any;
+
   constructor(status: string, action: string, reason: string) {
     this.time = DateTime.fromISO('2024-02-27T09:12:33.018+11:00');
     this.accountId = randomBytes(20).toString('hex');
+    this.region = 'ap-southeast-2';
     this.plugin = 'fakeplugin';
     this.driver = 'fakedriver';
     this.resourceType = 'type_' + randomBytes(20).toString('hex');

--- a/test/lib/resourceLog.spec.ts
+++ b/test/lib/resourceLog.spec.ts
@@ -40,6 +40,10 @@ class FakeResource extends ToolingInterface {
   get resourceTags(): { [key: string]: string } {
     return {};
   }
+
+  get sizing(): any {
+    return {};
+  }
 }
 
 const RESOURCE_LOG_CONFIG = {

--- a/test/plugins/powercycleCentral.config.yaml
+++ b/test/plugins/powercycleCentral.config.yaml
@@ -17,6 +17,8 @@ defaults:
       csv:
         file: ./test/plugins/audit.%name.%accountId.csv
         append: true
+      json:
+        file: ./test/plugins/audit.%name.%accountId.json
     excludeResources:
       - tag: 'Schedule|ignore'
 


### PR DESCRIPTION
Adds `region` and `sizing` to audit log entries.

* Region is taken from the plugin account config.
* Sizing is specified per resource and acts as a subset of fields from the `resource` object that relate directly to pricing the resource. Intended to aid in determining revolver cost savings.