### PR TITLE
Use the local AWS region when using STS, rather than an explicit region matching the client to be created

### DIFF
--- a/lib/assume.ts
+++ b/lib/assume.ts
@@ -27,24 +27,25 @@ class RemoteCredentials {
     return accountId;
   }
 
-  async connectTo(remoteRole: string, region?: string): Promise<Credentials | Provider<Credentials>> {
-    // logger.debug(`Requested connection via ${remoteRole}`);
+  async connectTo(remoteRole: string): Promise<Credentials | Provider<Credentials>> {
     if (remoteRole === undefined || remoteRole.endsWith('/none')) {
       return fromNodeProviderChain();
     }
 
     if (remoteRole in this.creds) {
-      if (this.creds[remoteRole].expiration > DateTime.now().setZone('UTC')) {
-        logger.debug(`Role ${remoteRole} is cached, will expire at ${this.creds[remoteRole].expiration}`);
+      const expiration = this.creds[remoteRole].expiration;
+      if (expiration > DateTime.now().setZone('UTC')) {
+        logger.debug(`Role ${remoteRole} is cached, will expire at ${expiration}`);
         return this.creds[remoteRole].creds;
       }
-      logger.debug(
-        `Cached role ${remoteRole} expired at ${this.creds[remoteRole].expiration}, requesting new creds...`,
-      );
+      logger.debug(`Cached role ${remoteRole} expired at ${expiration}, requesting new creds...`);
     }
 
-    const awsConfig = getAwsConfig(region || 'ap-southeast-2');
-    logger.debug(`Assuming role ${remoteRole} in ${awsConfig.region}...`);
+    // Use the following environment variables to determine which region to use for the STS service.
+    // See https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime
+    const region = process.env['AWS_REGION'] || process.env['AWS_DEFAULT_REGION'] || 'ap-southeast-2'; // provide a default
+    const awsConfig = getAwsConfig(region);
+    logger.debug(`Assuming role ${remoteRole} in ${region}...`);
     const sts = new STS(awsConfig);
     const creds = await sts
       .assumeRole({
@@ -54,7 +55,7 @@ class RemoteCredentials {
       .then((r) => r.Credentials);
 
     if (!creds) {
-      throw new Error(`Unable to assume role ${remoteRole} in ${awsConfig.region}, got empty creds`);
+      throw new Error(`Unable to assume role ${remoteRole}, got empty creds`);
     }
     if (creds.Expiration === undefined) {
       throw new Error(`Credentials have no expiry time`);

--- a/lib/assume.ts
+++ b/lib/assume.ts
@@ -28,7 +28,7 @@ class RemoteCredentials {
   }
 
   async connectTo(remoteRole: string, region?: string): Promise<Credentials | Provider<Credentials>> {
-    logger.debug(`Requested connection via ${remoteRole}`);
+    // logger.debug(`Requested connection via ${remoteRole}`);
     if (remoteRole === undefined || remoteRole.endsWith('/none')) {
       return fromNodeProviderChain();
     }
@@ -43,8 +43,8 @@ class RemoteCredentials {
       );
     }
 
-    logger.debug(`Assuming role ${remoteRole}...`);
     const awsConfig = getAwsConfig(region || 'ap-southeast-2');
+    logger.debug(`Assuming role ${remoteRole} in ${awsConfig.region}...`);
     const sts = new STS(awsConfig);
     const creds = await sts
       .assumeRole({
@@ -54,7 +54,7 @@ class RemoteCredentials {
       .then((r) => r.Credentials);
 
     if (!creds) {
-      throw new Error(`Unable to assume role ${remoteRole}, got empty creds`);
+      throw new Error(`Unable to assume role ${remoteRole} in ${awsConfig.region}, got empty creds`);
     }
     if (creds.Expiration === undefined) {
       throw new Error(`Credentials have no expiry time`);

--- a/lib/awsConfig.ts
+++ b/lib/awsConfig.ts
@@ -35,7 +35,7 @@ type Ctor<U> = new (stuff: object) => U;
 
 // Helper function to get a specific AWS client for the given role/region
 async function getAwsClient<T>(ctor: Ctor<T>, remoteRole: string, region: string): Promise<T> {
-  const creds = await assume.connectTo(remoteRole, region);
+  const creds = await assume.connectTo(remoteRole);
   const config = getAwsConfig(region, creds);
   return new ctor(config);
 }


### PR DESCRIPTION
Per https://github.com/Innablr/revolver/issues/311

Code also includes minor cleanup to make a constant `expiration` to shorten code.