### PR TITLE
Handle resource launch times which are already JSDate

### DIFF
--- a/drivers/ebs.ts
+++ b/drivers/ebs.ts
@@ -5,13 +5,13 @@ import {
   paginateDescribeVolumes,
   paginateDescribeInstances,
 } from '@aws-sdk/client-ec2';
-import { DateTime } from 'luxon';
 import { makeResourceTags, paginateAwsCall } from '../lib/common.js';
 import { InstrumentedResource, ToolingInterface } from './instrumentedResource.js';
 import { DriverInterface } from './driverInterface.js';
 import { RevolverAction, RevolverActionWithTags } from '../actions/actions.js';
 import { ec2Tagger } from './tags.js';
 import { getAwsClientForAccount } from '../lib/awsConfig.js';
+import dateTime from '../lib/dateTime.js';
 
 class InstrumentedEBS extends ToolingInterface {
   private volumeARN: string;
@@ -38,7 +38,7 @@ class InstrumentedEBS extends ToolingInterface {
   }
 
   get launchTimeUtc() {
-    return DateTime.fromISO(this.resource.LaunchTime).setZone('utc');
+    return dateTime.getUtcDateTime(this.resource.LaunchTime);
   }
 
   tag(key: string) {

--- a/drivers/ec2.ts
+++ b/drivers/ec2.ts
@@ -1,4 +1,3 @@
-import { DateTime } from 'luxon';
 import {
   AutoScalingClient,
   ResumeProcessesCommand,
@@ -19,6 +18,7 @@ import { RevolverAction, RevolverActionWithTags } from '../actions/actions.js';
 import { chunkArray, makeResourceTags, paginateAwsCall } from '../lib/common.js';
 import { ec2Tagger } from './tags.js';
 import { getAwsClientForAccount } from '../lib/awsConfig.js';
+import dateTime from '../lib/dateTime.js';
 
 class InstrumentedEc2 extends ToolingInterface {
   private instanceARN: string;
@@ -41,7 +41,7 @@ class InstrumentedEc2 extends ToolingInterface {
   }
 
   get launchTimeUtc() {
-    return DateTime.fromISO(this.resource.LaunchTime).setZone('utc');
+    return dateTime.getUtcDateTime(this.resource.LaunchTime);
   }
 
   get resourceState() {

--- a/drivers/ec2.ts
+++ b/drivers/ec2.ts
@@ -26,6 +26,9 @@ class InstrumentedEc2 extends ToolingInterface {
   constructor(resource: Instance, instanceARN: string) {
     super(resource);
     this.instanceARN = instanceARN;
+    if (this.resourceState == 'running') {
+      this.metadata.uptime = dateTime.calculateUptime(this.launchTimeUtc).toFixed(2);
+    }
   }
 
   get resourceId() {
@@ -41,6 +44,7 @@ class InstrumentedEc2 extends ToolingInterface {
   }
 
   get launchTimeUtc() {
+    // If a resource is stopped, this still contains the original launch time
     return dateTime.getUtcDateTime(this.resource.LaunchTime);
   }
 

--- a/drivers/rdsCluster.ts
+++ b/drivers/rdsCluster.ts
@@ -1,4 +1,3 @@
-import { DateTime } from 'luxon';
 import {
   DescribeDBClustersCommand,
   DescribeDBInstancesCommand,
@@ -13,6 +12,7 @@ import { RevolverAction, RevolverActionWithTags } from '../actions/actions.js';
 import { rdsTagger } from './tags.js';
 import { getAwsClientForAccount } from '../lib/awsConfig.js';
 import { makeResourceTags } from '../lib/common.js';
+import dateTime from '../lib/dateTime.js';
 
 class InstrumentedRdsCluster extends ToolingInterface {
   constructor(awsResource: any) {
@@ -34,7 +34,7 @@ class InstrumentedRdsCluster extends ToolingInterface {
   }
 
   get launchTimeUtc() {
-    return DateTime.fromISO(this.resource.ClusterCreateTime).setZone('UTC');
+    return dateTime.getUtcDateTime(this.resource.ClusterCreateTime);
   }
 
   get resourceState() {

--- a/drivers/rdsInstance.ts
+++ b/drivers/rdsInstance.ts
@@ -1,4 +1,3 @@
-import { DateTime } from 'luxon';
 import {
   DescribeDBInstancesCommand,
   ListTagsForResourceCommand,
@@ -13,6 +12,7 @@ import { RevolverAction, RevolverActionWithTags } from '../actions/actions.js';
 import { rdsTagger } from './tags.js';
 import { getAwsClientForAccount } from '../lib/awsConfig.js';
 import { makeResourceTags } from '../lib/common.js';
+import dateTime from '../lib/dateTime.js';
 
 class InstrumentedRdsInstance extends ToolingInterface {
   public tags: Tag[] = [];
@@ -40,7 +40,7 @@ class InstrumentedRdsInstance extends ToolingInterface {
   }
 
   get launchTimeUtc() {
-    return DateTime.fromISO(this.resource.InstanceCreateTime).setZone('UTC');
+    return dateTime.getUtcDateTime(this.resource.InstanceCreateTime);
   }
 
   get isAvailable() {

--- a/drivers/redshiftCluster.ts
+++ b/drivers/redshiftCluster.ts
@@ -1,4 +1,3 @@
-import { DateTime } from 'luxon';
 import {
   Cluster,
   CreateTagsCommand,

--- a/drivers/redshiftCluster.ts
+++ b/drivers/redshiftCluster.ts
@@ -34,7 +34,7 @@ class InstrumentedRedshiftCluster extends ToolingInterface {
   }
 
   get launchTimeUtc() {
-    return DateTime.fromISO(this.resource.ClusterCreateTime).setZone('UTC');
+    return dateTime.getUtcDateTime(this.resource.ClusterCreateTime);
   }
 
   get nodes() {

--- a/drivers/redshiftClusterSnapshot.ts
+++ b/drivers/redshiftClusterSnapshot.ts
@@ -1,4 +1,3 @@
-import { DateTime } from 'luxon';
 import {
   Cluster,
   CreateTagsCommand,
@@ -16,6 +15,7 @@ import { DriverInterface } from './driverInterface.js';
 import { RevolverAction, RevolverActionWithTags } from '../actions/actions.js';
 import { getAwsClientForAccount } from '../lib/awsConfig.js';
 import { makeResourceTags } from '../lib/common.js';
+import dateTime from '../lib/dateTime.js';
 
 class InstrumentedRedshiftClusterSnapshot extends ToolingInterface {
   public tags: Tag[] = [];
@@ -35,7 +35,7 @@ class InstrumentedRedshiftClusterSnapshot extends ToolingInterface {
   }
 
   get launchTimeUtc() {
-    return DateTime.fromISO(this.resource.SnapshotCreateTime).setZone('UTC');
+    return dateTime.getUtcDateTime(this.resource.SnapshotCreateTime);
   }
 
   get resourceState() {

--- a/drivers/snapshot.ts
+++ b/drivers/snapshot.ts
@@ -1,4 +1,3 @@
-import { DateTime } from 'luxon';
 import {
   EC2Client,
   Tag,
@@ -12,6 +11,7 @@ import { RevolverActionWithTags } from '../actions/actions.js';
 import { makeResourceTags, paginateAwsCall } from '../lib/common.js';
 import { ec2Tagger } from './tags.js';
 import { getAwsClientForAccount } from '../lib/awsConfig.js';
+import dateTime from '../lib/dateTime.js';
 
 class InstrumentedSnapshot extends ToolingInterface {
   get resourceId() {
@@ -23,7 +23,7 @@ class InstrumentedSnapshot extends ToolingInterface {
   }
 
   get launchTimeUtc() {
-    return DateTime.fromISO(this.resource.StartTime).setZone('utc');
+    return dateTime.getUtcDateTime(this.resource.StartTime);
   }
 
   get resourceState() {

--- a/lib/dateTime.ts
+++ b/lib/dateTime.ts
@@ -31,15 +31,29 @@ class DateTime {
   }
 
   /**
-   * Convert either a String or a JSDate to a LuxonDateTime in UTC
+   * Convert a String|JSDate|LuxonDateTime to a LuxonDateTime in UTC
    * @param from - either a Date or a String that looks like a date
    * @returns a Luxon DateTime
    */
-  getUtcDateTime(from: string | Date): LuxonDateTime {
-    if (typeof from == 'object') {
+  getUtcDateTime(from: string | Date | LuxonDateTime | null): LuxonDateTime {
+    if (from === null) {
+      return LuxonDateTime.invalid('null');
+    } else if (from instanceof LuxonDateTime) {
+      return from.setZone('utc');
+    } else if (from instanceof Date) {
       return LuxonDateTime.fromJSDate(from).setZone('utc');
+    } else {
+      return LuxonDateTime.fromISO(from).setZone('utc');
     }
-    return LuxonDateTime.fromISO(from).setZone('utc');
+  }
+
+  /**
+   * Calculate the uptime between the given date and now/frozen time, in hours.
+   * @param from - the time a resource was started
+   * @returns the uptime since then in hours
+   */
+  calculateUptime(from: LuxonDateTime): number {
+    return this.currentTime.diff(from).as('hours');
   }
 }
 

--- a/lib/dateTime.ts
+++ b/lib/dateTime.ts
@@ -29,6 +29,18 @@ class DateTime {
     }
     return this.currentTime;
   }
+
+  /**
+   * Convert either a String or a JSDate to a LuxonDateTime in UTC
+   * @param from - either a Date or a String that looks like a date
+   * @returns a Luxon DateTime
+   */
+  getUtcDateTime(from: string | Date): LuxonDateTime {
+    if (typeof from == 'object') {
+      return LuxonDateTime.fromJSDate(from).setZone('utc');
+    }
+    return LuxonDateTime.fromISO(from).setZone('utc');
+  }
 }
 
 const dateTime = new DateTime();

--- a/test/lib/dateTime.spec.ts
+++ b/test/lib/dateTime.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import dateTime from '../../lib/dateTime.js';
-import { FixedOffsetZone } from 'luxon';
+import { FixedOffsetZone, DateTime as LuxonDateTime } from 'luxon';
 
 describe('Validate DateTime', function () {
   it('Check DateTime freeze', async function () {
@@ -22,5 +22,51 @@ describe('Validate DateTime', function () {
     expect(d5.invalidReason).to.equal('unparsable');
     expect(d5.toISO()).to.be.null;
     console.info('D5: %s', d5);
+  });
+
+  it('Check DateTime getUtcDateTime', async function () {
+    // check basic Luxon date
+    const nowUTC = LuxonDateTime.utc();
+    const d1 = LuxonDateTime.utc(2017, 3, 12, 5, 45, 10, 765, { locale: 'fr' }); //~> 2017-03-12T05:45:10.765Z with a French locale
+    expect(d1.invalidReason).to.be.null;
+    expect(d1.isValid).to.be.true;
+    expect(d1.zone).to.equal(nowUTC.zone);
+    expect(d1.toISO()).to.equal('2017-03-12T05:45:10.765Z');
+
+    // check non-UTC timezone
+    const d2 = d1.setZone('Australia/Melbourne');
+    expect(d2.invalidReason).to.be.null;
+    expect(d2.isValid).to.be.true;
+    expect(d2.zone).to.not.equal(nowUTC.zone);
+    expect(d2.toISO()).to.equal('2017-03-12T16:45:10.765+11:00');
+
+    // check LuxonDate (non-UTC) variant of getUtcDateTime
+    const d3 = dateTime.getUtcDateTime(d2);
+    expect(d3.invalidReason).to.be.null;
+    expect(d3.isValid).to.be.true;
+    expect(d3.zone).to.equal(nowUTC.zone);
+    expect(d3.toISO()).to.equal('2017-03-12T05:45:10.765Z');
+
+    // check JS Date (non-UTC) variant of getUtcDateTime
+    const d4 = dateTime.getUtcDateTime(d2.toJSDate());
+    expect(d4.invalidReason).to.be.null;
+    expect(d4.isValid).to.be.true;
+    expect(d4.zone).to.equal(nowUTC.zone);
+    expect(d4.toISO()).to.equal('2017-03-12T05:45:10.765Z');
+
+    // check String Date (non-UTC) variant of getUtcDateTime
+    const d5 = dateTime.getUtcDateTime(d2.toISO());
+    expect(d5.invalidReason).to.be.null;
+    expect(d5.isValid).to.be.true;
+    expect(d5.zone).to.equal(nowUTC.zone);
+    expect(d5.toISO()).to.equal('2017-03-12T05:45:10.765Z');
+  });
+
+  it('Check DateTime calculateUptime', async function () {
+    const now = LuxonDateTime.utc();
+    const previous = now.minus({ minutes: 60 * 5 + 12 });
+    dateTime.freezeTime(now.toISO());
+    const uptime = dateTime.calculateUptime(previous);
+    expect(uptime).to.equal(5.2);
   });
 });


### PR DESCRIPTION
At the moment, all the top-level launchTimeUtc values in the resource dump are null.  This is because the data-type of the resource launchTimeUtc is JS Date, not string.  See https://github.com/Innablr/revolver/issues/370