### PR TITLE
Use a static RoleSessionName to make it easier to find in CloudTrail

### DIFF
--- a/lib/assume.ts
+++ b/lib/assume.ts
@@ -1,6 +1,5 @@
 import { logger } from './logger.js';
 import { STS } from '@aws-sdk/client-sts';
-import dateTime from './dateTime.js';
 import { DateTime } from 'luxon';
 import { AwsCredentialIdentity as Credentials, Provider } from '@aws-sdk/types';
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
@@ -50,7 +49,7 @@ class RemoteCredentials {
     const creds = await sts
       .assumeRole({
         RoleArn: remoteRole,
-        RoleSessionName: `Revolver_${dateTime.getTime().toFormat('yyyyLLddHHmmss')}`,
+        RoleSessionName: 'Revolver',
       })
       .then((r) => r.Credentials);
 


### PR DESCRIPTION
Per #373 - otherwise every invocation of Revolver uses a unique session name (appears as User Name in console).