### PR TITLE
Add timestamps to resource CSV output

### DIFF
--- a/lib/accountRevolver.ts
+++ b/lib/accountRevolver.ts
@@ -14,6 +14,7 @@ import {
   ObjectLogHtml,
   resetFileLogger,
 } from './objectLog.js';
+import dateTime from './dateTime.js';
 
 export class AccountRevolver {
   readonly supportedDrivers = [
@@ -188,7 +189,9 @@ export class AccountRevolver {
             break;
           case 'csv':
             await new ObjectLogCsv(
-              new ResourceTable(this.config, this.resources, resourceLogConfig?.reportTags),
+              new ResourceTable(this.config, this.resources, resourceLogConfig?.reportTags, {
+                TIME: dateTime.getTime().toISO(),
+              }),
               resourceLogConfig,
               context,
             ).process();

--- a/lib/config-schema.ts
+++ b/lib/config-schema.ts
@@ -106,6 +106,7 @@ const Settings = z.object({
       html: ObjectLogOptions.optional(),
       csv: z
         .object({
+          append: z.boolean().default(false),
           reportTags: z.array(z.string()).optional(),
         })
         .merge(ObjectLogOptions)

--- a/lib/objectLog.ts
+++ b/lib/objectLog.ts
@@ -364,20 +364,23 @@ export class ResourceTable implements DataTable {
   private readonly reportTags: string[];
   private readonly entries: ToolingInterface[];
   private readonly accountConfig: any;
-  constructor(accountConfig: any, entries: ToolingInterface[], reportTags: string[]) {
+  private readonly staticValues: any;
+  constructor(accountConfig: any, entries: ToolingInterface[], reportTags: string[], staticValues = {}) {
     this.accountConfig = accountConfig;
     this.reportTags = reportTags || [];
     this.entries = entries;
+    this.staticValues = staticValues;
   }
 
   header(): string[] {
-    return ['ACCOUNT_ID', 'ACCOUNT_NAME', 'REGION', 'TYPE', 'ID', 'STATE', 'ACTIONS'].concat(
-      this.reportTags.map((t) => `TAG:${t}`),
-    );
+    const columnNames = ['ACCOUNT_ID', 'ACCOUNT_NAME', 'REGION', 'TYPE', 'ID', 'STATE', 'ACTIONS'];
+    const tagColumns = this.reportTags.map((t) => `TAG:${t}`);
+    return [...Object.keys(this.staticValues), ...columnNames, ...tagColumns];
   }
   data(): string[][] {
     return this.entries.map((e) => {
       return [
+        ...Object.values(this.staticValues),
         e.accountId,
         this.accountConfig.settings.name,
         e.region,

--- a/test/lib/resourceLog.spec.ts
+++ b/test/lib/resourceLog.spec.ts
@@ -131,6 +131,16 @@ describe('Validate ResourceLog', function () {
     expect(records[0].ID).to.equal('donkey1');
     expect(records[0].TYPE).to.equal('donkey');
     expect(records[0].STATE).to.equal('running');
+    // Check CSV append
+    const newConfig = Object.assign({}, RESOURCE_LOG_CONFIG.csv, { append: true });
+    await new ObjectLogCsv(
+      new ResourceTable(ACCOUNT_CONFIG, TEST_RESOURCES, newConfig.reportTags, { SPAM: '123' }),
+      newConfig,
+      ACCOUNT_CONFIG.settings,
+    ).process();
+    const auditCsvText2 = fs.readFileSync(newConfig.file, 'utf-8');
+    const records2 = parse(auditCsvText2, { bom: true, columns: true });
+    expect(records2.length).to.equal(8);
   });
 
   it('Check ObjectLogJson', async function () {

--- a/test/lib/resourceLog.spec.ts
+++ b/test/lib/resourceLog.spec.ts
@@ -5,6 +5,7 @@ import { DateTime } from 'luxon';
 import { randomBytes } from 'node:crypto';
 import * as fs from 'node:fs';
 import dateTime from '../../lib/dateTime.js';
+import { parse } from 'csv-parse/sync';
 
 // A dummy AWS resource for testing
 class FakeResource extends ToolingInterface {
@@ -117,14 +118,19 @@ describe('Validate ResourceLog', function () {
   it('Check ObjectLogCsv resources', async function () {
     if (fs.existsSync(RESOURCE_LOG_CONFIG.csv.file)) fs.unlinkSync(RESOURCE_LOG_CONFIG.csv.file);
     await new ObjectLogCsv(
-      new ResourceTable(ACCOUNT_CONFIG, TEST_RESOURCES, RESOURCE_LOG_CONFIG.csv.reportTags),
+      new ResourceTable(ACCOUNT_CONFIG, TEST_RESOURCES, RESOURCE_LOG_CONFIG.csv.reportTags, { SPAM: '123' }),
       RESOURCE_LOG_CONFIG.csv,
       ACCOUNT_CONFIG.settings,
     ).process();
     expect(fs.existsSync(RESOURCE_LOG_CONFIG.csv.file)).to.be.true;
-    // TODO: check the contents of RESOURCE_LOG_CONFIG.csv.file
-    const resourceCsvText = fs.readFileSync(RESOURCE_LOG_CONFIG.csv.file, 'utf-8');
-    expect((resourceCsvText.match(/DoThis\|DoThat/g) || []).length).to.equal(4); // number of rows
+    // Check the contents of RESOURCE_LOG_CONFIG.csv.file
+    const auditCsvText = fs.readFileSync(RESOURCE_LOG_CONFIG.csv.file, 'utf-8');
+    const records = parse(auditCsvText, { bom: true, columns: true });
+    expect(records.length).to.equal(4);
+    expect(records[0].SPAM).to.equal('123');
+    expect(records[0].ID).to.equal('donkey1');
+    expect(records[0].TYPE).to.equal('donkey');
+    expect(records[0].STATE).to.equal('running');
   });
 
   it('Check ObjectLogJson', async function () {


### PR DESCRIPTION
Per #375
- add support for static key:value items in ResourceTable
- add tests for static columns, add tests for CSV append
- support append=true in resource-log configuration
- add TIME:isodate column to resource CSV output
