### PR TITLE
Per #377 include (only) the selected matcher in CSV output

### DIFF
--- a/lib/objectLog.ts
+++ b/lib/objectLog.ts
@@ -373,10 +373,11 @@ export class ResourceTable implements DataTable {
   }
 
   header(): string[] {
-    const columnNames = ['ACCOUNT_ID', 'ACCOUNT_NAME', 'REGION', 'TYPE', 'ID', 'STATE', 'ACTIONS'];
+    const columnNames = ['ACCOUNT_ID', 'ACCOUNT_NAME', 'REGION', 'TYPE', 'ID', 'STATE', 'MATCHER', 'ACTIONS'];
     const tagColumns = this.reportTags.map((t) => `TAG:${t}`);
     return [...Object.keys(this.staticValues), ...columnNames, ...tagColumns];
   }
+
   data(): string[][] {
     return this.entries.map((e) => {
       return [
@@ -387,6 +388,7 @@ export class ResourceTable implements DataTable {
         e.resourceType,
         e.resourceId,
         e.resourceState,
+        e?.metadata?.highestMatch,
         (e?.metadata?.actionNames || []).join('|'),
       ].concat(this.reportTags.map((t) => e.tag(t) || ''));
     });

--- a/plugins/powercycle.ts
+++ b/plugins/powercycle.ts
@@ -51,6 +51,7 @@ export default class PowerCyclePlugin extends RevolverPlugin {
 
     logger.debug(`Checking availability ${scheduleTag}`);
     const [r, reason] = this.parser(scheduleTag, localTimeNow);
+    resource.metadata.highestMatch = `Tag:${this.scheduleTagName} (${scheduleTag})`;
 
     switch (r) {
       case 'UNPARSEABLE':

--- a/plugins/powercycleCentral.ts
+++ b/plugins/powercycleCentral.ts
@@ -103,13 +103,13 @@ export default class PowerCycleCentralPlugin extends RevolverPlugin {
     });
 
     // Add list of all the matched Matchers to the resource metadata
-    resource.metadata.matches = allMatches.map((matcher: Matcher) => {
-      return {
-        name: matcher.name,
-        schedule: matcher.schedule,
-        priority: matcher.priority,
-      };
-    });
+    // resource.metadata.matches = allMatches.map((matcher: Matcher) => {
+    //   return {
+    //     name: matcher.name,
+    //     schedule: matcher.schedule,
+    //     priority: matcher.priority,
+    //   };
+    // });
 
     let highestMatch = allMatches[0]; // undefined if no matches
     const taggedSchedule = resource.tag(this.scheduleTagName);
@@ -131,6 +131,7 @@ export default class PowerCycleCentralPlugin extends RevolverPlugin {
 
     logger.debug(`Match for "${highestMatch.name}". Checking availability ${highestMatch.schedule}`);
     const [r, reason] = this.parser(highestMatch.schedule, localTimeNow);
+    resource.metadata.highestMatch = `${highestMatch.name} (${highestMatch.schedule})`;
 
     switch (r) {
       case 'UNPARSEABLE':

--- a/test/plugins/powercycleCentral.spec.ts
+++ b/test/plugins/powercycleCentral.spec.ts
@@ -126,7 +126,9 @@ describe('Run powercycleCentral full cycle', function () {
         const a1_resourcecsv_file = getOutputFilename(0, OutputFiles.ResourcesCsv);
         const a1_resourcecsv_text = fs.readFileSync(a1_resourcecsv_file, 'utf-8');
         expect(a1_resourcecsv_text).to.include(',TAG:Name,TAG:Schedule');
-        expect(a1_resourcecsv_text).to.include('i-0c688d35209d7f436,running,Tag:Schedule (0x7),StopAction,junk-vm-2-on,0x7');
+        expect(a1_resourcecsv_text).to.include(
+          'i-0c688d35209d7f436,running,Tag:Schedule (0x7),StopAction,junk-vm-2-on,0x7',
+        );
         expect(a1_resourcecsv_text).to.not.include('777777777777,'); // don't include excluded account
         expect(a1_resourcecsv_text).to.not.include('888888888888,'); // under different filename
         expect(a1_resourcecsv_text).to.not.include(',i-B7781A749688DAD2,'); // under different filename
@@ -141,7 +143,9 @@ describe('Run powercycleCentral full cycle', function () {
         expect(a1_resources_by_id['i-0c688d35209d7f436'].metadata.actionNames.length).to.equal(1);
         expect(a1_resources_by_id['i-0c688d35209d7f436'].metadata.actionNames[0]).to.equal('StopAction');
         expect(a1_resources_by_id['i-05b6baf37fc8f9454'].resourceState).to.equal('running');
-        expect(a1_resources_by_id['i-05b6baf37fc8f9454'].metadata.highestMatch).to.equal('first asg (Start=08:00|mon-fri;Stop=18:00|mon-fri)');
+        expect(a1_resources_by_id['i-05b6baf37fc8f9454'].metadata.highestMatch).to.equal(
+          'first asg (Start=08:00|mon-fri;Stop=18:00|mon-fri)',
+        );
         expect(a1_resources_by_id['i-05b6baf37fc8f9454'].metadata.actionNames).to.equal(undefined);
 
         // validate account 2 resources file

--- a/test/plugins/powercycleCentral.spec.ts
+++ b/test/plugins/powercycleCentral.spec.ts
@@ -126,7 +126,7 @@ describe('Run powercycleCentral full cycle', function () {
         const a1_resourcecsv_file = getOutputFilename(0, OutputFiles.ResourcesCsv);
         const a1_resourcecsv_text = fs.readFileSync(a1_resourcecsv_file, 'utf-8');
         expect(a1_resourcecsv_text).to.include(',TAG:Name,TAG:Schedule');
-        expect(a1_resourcecsv_text).to.include('i-0c688d35209d7f436,running,StopAction,junk-vm-2-on,0x7');
+        expect(a1_resourcecsv_text).to.include('i-0c688d35209d7f436,running,Tag:Schedule (0x7),StopAction,junk-vm-2-on,0x7');
         expect(a1_resourcecsv_text).to.not.include('777777777777,'); // don't include excluded account
         expect(a1_resourcecsv_text).to.not.include('888888888888,'); // under different filename
         expect(a1_resourcecsv_text).to.not.include(',i-B7781A749688DAD2,'); // under different filename
@@ -137,12 +137,11 @@ describe('Run powercycleCentral full cycle', function () {
         const a1_resources_by_id = Object.fromEntries(a1_resources.map((r: any) => [r.resourceId, r]));
         expect(a1_resources.length).to.equal(10); // number of resources, in first account
         expect(a1_resources_by_id['i-0c688d35209d7f436'].resourceState).to.equal('running');
-        expect(a1_resources_by_id['i-0c688d35209d7f436'].metadata.matches.length).to.equal(1);
-        expect(a1_resources_by_id['i-0c688d35209d7f436'].metadata.matches[0].name).to.equal('everything off (p1)');
+        expect(a1_resources_by_id['i-0c688d35209d7f436'].metadata.highestMatch).to.equal('Tag:Schedule (0x7)');
         expect(a1_resources_by_id['i-0c688d35209d7f436'].metadata.actionNames.length).to.equal(1);
         expect(a1_resources_by_id['i-0c688d35209d7f436'].metadata.actionNames[0]).to.equal('StopAction');
         expect(a1_resources_by_id['i-05b6baf37fc8f9454'].resourceState).to.equal('running');
-        expect(a1_resources_by_id['i-05b6baf37fc8f9454'].metadata.matches.length).to.equal(2);
+        expect(a1_resources_by_id['i-05b6baf37fc8f9454'].metadata.highestMatch).to.equal('first asg (Start=08:00|mon-fri;Stop=18:00|mon-fri)');
         expect(a1_resources_by_id['i-05b6baf37fc8f9454'].metadata.actionNames).to.equal(undefined);
 
         // validate account 2 resources file


### PR DESCRIPTION
Per #377 include (only) the selected matcher in CSV output. 

Formatted as `${highestMatch.name} (${highestMatch.schedule})`

<img width="1652" alt="image" src="https://github.com/Innablr/revolver/assets/122371/a783cee9-15fd-42db-9410-9b12a060f185">
