### PR TITLE
Use <= instead of < when comparing partial schedules

### DIFF
--- a/plugins/parsers/strict.ts
+++ b/plugins/parsers/strict.ts
@@ -78,8 +78,8 @@ class ParsedComponent {
     return this.dayFrom! <= d && d <= this.dayTo!;
   }
 
-  timePast(t: DateTime) {
-    return t.set({ hour: this.timeHour, minute: this.timeMinute }) < t;
+  timeEqualOrPast(t: DateTime) {
+    return t.set({ hour: this.timeHour, minute: this.timeMinute }) <= t;
   }
 }
 
@@ -207,7 +207,7 @@ function startOrStop(tag: string, timeNow: DateTime) {
   if (t.start.isSet) {
     const r = `It's now ${timeNow.toFormat(reasonDateFormat)}, resource starts at ${t.start.time} ${t.days ? t.days : 'all week'}`;
     if (t.dayIn(timeNow)) {
-      if (t.start.timePast(timeNow) && !t.start.timePast(timeNow.minus({ minutes: 15 }))) {
+      if (t.start.timeEqualOrPast(timeNow) && !t.start.timeEqualOrPast(timeNow.minus({ minutes: 15 }))) {
         return ['START', r];
       }
     }
@@ -217,7 +217,7 @@ function startOrStop(tag: string, timeNow: DateTime) {
   if (t.stop.isSet) {
     const r = `It's now ${timeNow.toFormat(reasonDateFormat)}, resource stops at ${t.stop.time} ${t.days ? t.days : 'all week'}`;
     if (t.dayIn(timeNow)) {
-      if (t.stop.timePast(timeNow) && !t.stop.timePast(timeNow.minus({ minutes: 15 }))) {
+      if (t.stop.timeEqualOrPast(timeNow) && !t.stop.timeEqualOrPast(timeNow.minus({ minutes: 15 }))) {
         return ['STOP', r];
       }
     }

--- a/test/parsers/parserStrict/handling.spec.ts
+++ b/test/parsers/parserStrict/handling.spec.ts
@@ -28,7 +28,9 @@ describe('Strict parser handles different corner cases', async function () {
       ['2024-02-19T10:00', 'start=08:30;stop=17:30', 'START'], // in window
       ['2024-02-19T10:00', 'start=12:30;stop=17:30', 'STOP'], // in pre-window stop
       ['2024-02-19T10:00', 'start=06:30;stop=07:30', 'STOP'], // in post-window stop
+      ['2024-02-19T09:59', 'start=10:00;stop=17:30', 'STOP'], // pre-window
       ['2024-02-19T10:00', 'start=10:00;stop=17:30', 'START'], // leading edge
+      ['2024-02-19T10:01', 'start=10:00;stop=17:30', 'START'], // in window
       ['2024-02-19T17:29', 'start=10:00;stop=17:30', 'START'], // trailing edge
       ['2024-02-19T17:30', 'start=10:00;stop=17:30', 'STOP'], // trailing edge
       ['2024-02-19T17:31', 'start=10:00;stop=17:30', 'STOP'], // trailing edge

--- a/test/parsers/parserStrict/handling.spec.ts
+++ b/test/parsers/parserStrict/handling.spec.ts
@@ -51,10 +51,8 @@ describe('Strict parser handles different corner cases', async function () {
     ];
     cases.forEach(function ([testTime, tag, answer]) {
       it(`when ${testTime} and Schedule ${tag} -> ${answer}`, function () {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const [action, reason] = strictParser(tag, DateTime.fromISO(testTime));
         expect(action).to.equal(answer, reason);
-        // expect(strictParser(c, timeNow)).to.have.ordered.members(er);
       });
     });
   });

--- a/test/parsers/parserStrict/handling.spec.ts
+++ b/test/parsers/parserStrict/handling.spec.ts
@@ -21,4 +21,39 @@ describe('Strict parser handles different corner cases', async function () {
       });
     });
   });
+  describe('Strict parser handles non-window edge cases', function () {
+    // Test Time, Schedule, Action
+    const cases = [
+      // baseline
+      ['2024-02-19T10:00', 'start=08:30;stop=17:30', 'START'], // in window
+      ['2024-02-19T10:00', 'start=12:30;stop=17:30', 'STOP'], // in pre-window stop
+      ['2024-02-19T10:00', 'start=06:30;stop=07:30', 'STOP'], // in post-window stop
+      ['2024-02-19T10:00', 'start=10:00;stop=17:30', 'START'], // leading edge
+      ['2024-02-19T17:29', 'start=10:00;stop=17:30', 'START'], // trailing edge
+      ['2024-02-19T17:30', 'start=10:00;stop=17:30', 'STOP'], // trailing edge
+      ['2024-02-19T17:31', 'start=10:00;stop=17:30', 'STOP'], // trailing edge
+      // stop-only
+      ['2024-02-19T09:59', 'stop=10:00', 'NOOP'], // not yet
+      ['2024-02-19T10:00', 'stop=10:00', 'STOP'], // stop now
+      ['2024-02-19T10:05', 'stop=10:00', 'STOP'], // in stop window (15 mins)
+      ['2024-02-19T10:14', 'stop=10:00', 'STOP'], // in stop window (15 mins)
+      ['2024-02-19T10:15', 'stop=10:00', 'NOOP'], // outside window
+      ['2024-02-19T10:20', 'stop=10:00', 'NOOP'], // outside window
+      // start-only
+      ['2024-02-19T09:59', 'start=10:00', 'NOOP'], // not yet
+      ['2024-02-19T10:00', 'start=10:00', 'START'], // start now
+      ['2024-02-19T10:05', 'start=10:00', 'START'], // in start window (15 mins)
+      ['2024-02-19T10:14', 'start=10:00', 'START'], // in start window (15 mins)
+      ['2024-02-19T10:15', 'start=10:00', 'NOOP'], // outside window
+      ['2024-02-19T10:20', 'start=10:00', 'NOOP'], // outside window
+    ];
+    cases.forEach(function ([testTime, tag, answer]) {
+      it(`when ${testTime} and Schedule ${tag} -> ${answer}`, function () {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const [action, reason] = strictParser(tag, DateTime.fromISO(testTime));
+        expect(action).to.equal(answer, reason);
+        // expect(strictParser(c, timeNow)).to.have.ordered.members(er);
+      });
+    });
+  });
 });

--- a/test/parsers/parserStrict/scheduleWindow.ts
+++ b/test/parsers/parserStrict/scheduleWindow.ts
@@ -47,10 +47,7 @@ it('Strict parser calculates coverage correctly', async function () {
 });
 
 it('Check Luxon Interval Edges', async function () {
-  const interval = Interval.fromDateTimes(
-    DateTime.fromISO('2024-02-19T10:00'),
-    DateTime.fromISO('2024-02-19T11:00'),
-  );
+  const interval = Interval.fromDateTimes(DateTime.fromISO('2024-02-19T10:00'), DateTime.fromISO('2024-02-19T11:00'));
   // Validate Luxon Interval includes the lower range, and excludes the upper range
   expect(interval.contains(DateTime.fromISO('2024-02-19T09:59:59.999'))).to.be.false;
   expect(interval.contains(DateTime.fromISO('2024-02-19T10:00'))).to.be.true;

--- a/test/parsers/parserStrict/scheduleWindow.ts
+++ b/test/parsers/parserStrict/scheduleWindow.ts
@@ -2,29 +2,45 @@ import getParser from '../../../plugins/parsers/index.js';
 import { expect } from 'chai';
 import { DateTime, Interval } from 'luxon';
 
-const timeNow = DateTime.now();
-
 it('Strict parser calculates coverage correctly', async function () {
   const testInterval = 15; // number of minutes between samples
   const testWindow = { days: 7 }; // over what interval to sample
+  const startTime = DateTime.utc(2017, 3, 12, 0, 0, 0, 0);
+  const interval = Interval.fromDateTimes(startTime, startTime.plus(testWindow));
+  const testTimes = interval.splitBy({ minutes: testInterval }).map((d) => d.start);
 
+  // Schedule String, Minutes per Week, Start Running
   const cases = [
-    ['24x7', 24 * 7 * 60],
-    ['24x5', 24 * 5 * 60],
-    ['0x7', 0],
-    ['Start=08:30;Stop=09:00', 30 * 7],
-    ['Start=08:30|mon-fri;Stop=09:00|mon-fri', 30 * 5],
-    ['Start=09:00|mon-fri;Stop=17:00|mon-fri', 8 * 60 * 5],
-    ['xxx', 0],
+    ['24x7', 24 * 7 * 60, false],
+    ['24x5', 24 * 5 * 60, false],
+    ['0x7', 0, false],
+    ['Start=08:30;Stop=09:00', 30 * 7, false],
+    ['Start=08:30|mon-fri;Stop=09:00|mon-fri', 30 * 5, false],
+    ['Start=09:00|mon-fri;Stop=17:00|mon-fri', 8 * 60 * 5, false],
+    ['xxx', 0, false],
+    ['xxx', 24 * 7 * 60, true],
+    ['Stop=23:00', 23 * 60, true], // run until 11pm
+    ['Stop=23:00', 0, false], // stopped, still stopped after 11pm
+    ['Start=23:00', 60 + 24 * 6 * 60, false], // 60 minutes at end of day 1, then 24h/d after
+    ['Start=23:00', 24 * 7 * 60, true], // started, still started after 11pm
+    // currently not supported - see https://github.com/Innablr/revolver/issues/382
+    // ['Start=08:30|mon;Stop=09:00|mon', 30],
+    // ['Start=08:30|mon,thu-fri;Stop=09:00|mon,thu-fri', 30 * 3],
+    // ['Start=08:30|mon-tue,thu-fri;Stop=09:00|mon-tue,thu-fri', 30 * 4],
+    // ['Start=08:30|mon-wed,fri;Stop=09:00|mon-tue,thu-fri', 30 * 4],
   ];
 
   const strictParser = await getParser('strict');
-  const interval = Interval.fromDateTimes(timeNow, timeNow.plus(testWindow));
-  const startTimes = interval.splitBy({ minutes: testInterval }).map((d) => d.start);
-  cases.forEach(([tag, answer]) => {
-    const numMinutes = startTimes.reduce((uptime, t) => {
+  cases.forEach(([tag, answer, startRunning]) => {
+    let isRunning = startRunning;
+    const numMinutes = testTimes.reduce((uptime, t) => {
       const [action] = strictParser(tag, t);
-      return action == 'START' ? uptime + testInterval : uptime;
+      if (action == 'START') {
+        isRunning = true;
+      } else if (action == 'STOP') {
+        isRunning = false;
+      }
+      return isRunning ? uptime + testInterval : uptime;
     }, 0);
     expect(numMinutes).to.equal(answer, `Checking >${tag}<`);
   });

--- a/test/parsers/parserStrict/scheduleWindow.ts
+++ b/test/parsers/parserStrict/scheduleWindow.ts
@@ -45,3 +45,15 @@ it('Strict parser calculates coverage correctly', async function () {
     expect(numMinutes).to.equal(answer, `Checking >${tag}<`);
   });
 });
+
+it('Check Luxon Interval Edges', async function () {
+  const interval = Interval.fromDateTimes(
+    DateTime.fromISO('2024-02-19T10:00'),
+    DateTime.fromISO('2024-02-19T11:00'),
+  );
+  // Validate Luxon Interval includes the lower range, and excludes the upper range
+  expect(interval.contains(DateTime.fromISO('2024-02-19T09:59:59.999'))).to.be.false;
+  expect(interval.contains(DateTime.fromISO('2024-02-19T10:00'))).to.be.true;
+  expect(interval.contains(DateTime.fromISO('2024-02-19T10:59:59.999'))).to.be.true;
+  expect(interval.contains(DateTime.fromISO('2024-02-19T11:00'))).to.be.false;
+});

--- a/test/parsers/parserStrict/startStopBarriers.spec.ts
+++ b/test/parsers/parserStrict/startStopBarriers.spec.ts
@@ -45,7 +45,7 @@ describe('Strict parser handles start/stop barriers', async function () {
   const strictParser = await getParser('strict');
   describe('Strict parser handles start barrier', function () {
     const tag = 'Start=06:30;Override=off';
-    ['monday629', 'monday630'].forEach(function (c) {
+    ['monday629', ].forEach(function (c) {
       it(`not start at ${startBarriers[c]}`, function () {
         const [action, reason] = strictParser(tag, startBarriers[c]);
         expect(action).to.equal('NOOP');
@@ -54,7 +54,7 @@ describe('Strict parser handles start/stop barriers', async function () {
         );
       });
     });
-    ['monday631', 'monday644', 'monday645'].forEach(function (c) {
+    ['monday630', 'monday631', 'monday644'].forEach(function (c) {
       it(`start at ${startBarriers[c]}`, function () {
         const [action, reason] = strictParser(tag, startBarriers[c]);
         expect(action).to.equal('START');
@@ -63,7 +63,7 @@ describe('Strict parser handles start/stop barriers', async function () {
         );
       });
     });
-    ['monday646'].forEach(function (c) {
+    ['monday645', 'monday646'].forEach(function (c) {
       it(`not start at ${startBarriers[c]}`, function () {
         const [action, reason] = strictParser(tag, startBarriers[c]);
         expect(action).to.equal('NOOP');
@@ -75,7 +75,7 @@ describe('Strict parser handles start/stop barriers', async function () {
   });
   describe('Strict parser handles stop barrier', function () {
     const tag = 'Stop=17:30;Override=off';
-    ['monday1729', 'monday1730'].forEach(function (c) {
+    ['monday1729'].forEach(function (c) {
       it(`not stop at ${stopBarriers[c]}`, function () {
         const [action, reason] = strictParser(tag, stopBarriers[c]);
         expect(action).to.equal('NOOP');
@@ -84,7 +84,7 @@ describe('Strict parser handles start/stop barriers', async function () {
         );
       });
     });
-    ['monday1731', 'monday1744', 'monday1745'].forEach(function (c) {
+    ['monday1730', 'monday1731', 'monday1744'].forEach(function (c) {
       it(`stop at ${stopBarriers[c]}`, function () {
         const [action, reason] = strictParser(tag, stopBarriers[c]);
         expect(action).to.equal('STOP');
@@ -93,7 +93,7 @@ describe('Strict parser handles start/stop barriers', async function () {
         );
       });
     });
-    ['monday1746'].forEach(function (c) {
+    ['monday1745', 'monday1746'].forEach(function (c) {
       it(`not stop at ${stopBarriers[c]}`, function () {
         const [action, reason] = strictParser(tag, stopBarriers[c]);
         expect(action).to.equal('NOOP');

--- a/test/parsers/parserStrict/startStopBarriers.spec.ts
+++ b/test/parsers/parserStrict/startStopBarriers.spec.ts
@@ -45,7 +45,7 @@ describe('Strict parser handles start/stop barriers', async function () {
   const strictParser = await getParser('strict');
   describe('Strict parser handles start barrier', function () {
     const tag = 'Start=06:30;Override=off';
-    ['monday629', ].forEach(function (c) {
+    ['monday629'].forEach(function (c) {
       it(`not start at ${startBarriers[c]}`, function () {
         const [action, reason] = strictParser(tag, startBarriers[c]);
         expect(action).to.equal('NOOP');


### PR DESCRIPTION
Per #385 . Includes a bunch of new tests, and updates to existing.
This makes partial schedules (those with only a Start or only a Stop) consistent with Window schedules (which have both).

```javascript
  const interval = Interval.fromDateTimes(DateTime.fromISO('2024-02-19T10:00'), DateTime.fromISO('2024-02-19T11:00'));
  // Validate Luxon Interval includes the lower range, and excludes the upper range
  expect(interval.contains(DateTime.fromISO('2024-02-19T09:59:59.999'))).to.be.false;
  expect(interval.contains(DateTime.fromISO('2024-02-19T10:00'))).to.be.true;
  expect(interval.contains(DateTime.fromISO('2024-02-19T10:59:59.999'))).to.be.true;
  expect(interval.contains(DateTime.fromISO('2024-02-19T11:00'))).to.be.false;
```
