### PR TITLE
Add utility for creating (account-aware) sub-loggers, and add sub-logger to a couple of places

### DIFF
--- a/drivers/driverInterface.ts
+++ b/drivers/driverInterface.ts
@@ -1,5 +1,5 @@
 import { Logger } from 'tslog';
-import { logger, RevolverLogObject } from '../lib/logger.js';
+import { RevolverLogObject, getSubLogger } from '../lib/logger.js';
 import { InstrumentedResource, ToolingInterface } from './instrumentedResource.js';
 import { RevolverAction } from '../actions/actions.js';
 import { ActionAuditEntry } from '../actions/audit.js';
@@ -17,10 +17,7 @@ export abstract class DriverInterface {
     this.accountConfig = accountConfig.settings;
     this.driverConfig = driverConfig;
     this.accountId = accountConfig.accountId;
-    this.logger = logger.getSubLogger(
-      { name: `${this.accountConfig.name}(${this.accountId})` },
-      { accountId: this.accountId, accountName: this.accountConfig.name, driverName: this.name },
-    );
+    this.logger = getSubLogger(this.accountConfig.name, this.accountId, { driverName: this.name });
     this.logger.debug(`Initialising driver ${this.name} for account ${this.accountConfig.name}`);
     this.actionAuditLog = [];
   }

--- a/lib/accountRevolver.ts
+++ b/lib/accountRevolver.ts
@@ -1,7 +1,7 @@
 import { DriverInterface } from '../drivers/driverInterface.js';
 import { InstrumentedResource, ToolingInterface } from '../drivers/instrumentedResource.js';
 import { RevolverPlugin } from '../plugins/pluginInterface.js';
-import { logger, getSubLogger } from './logger.js';
+import { getSubLogger } from './logger.js';
 import path from 'node:path';
 import { promises as fs } from 'node:fs';
 import { buildFilter } from '../plugins/filters/index.js';
@@ -156,10 +156,10 @@ export class AccountRevolver {
             ).process();
             break;
           default:
-            logger.warn(`no implementation for audit log format ${auditFormat}`);
+            this.logger.warn(`no implementation for audit log format ${auditFormat}`);
         }
       } catch (e: any) {
-        logger.error(`failed to write auditLog ${auditFormat}: ${e.message}`);
+        this.logger.error(`failed to write auditLog ${auditFormat}: ${e.message}`);
       }
     }
   }
@@ -194,11 +194,11 @@ export class AccountRevolver {
             ).process();
             break;
           default:
-            logger.warn(`no implementation for resource log format ${logFormat}`);
+            this.logger.warn(`no implementation for resource log format ${logFormat}`);
         }
       } catch (e: any) {
-        logger.error(e);
-        logger.error(`failed to write resourcesLog ${logFormat}: ${e.message}`);
+        this.logger.error(e);
+        this.logger.error(`failed to write resourcesLog ${logFormat}: ${e.message}`);
       }
     }
   }

--- a/lib/accountRevolver.ts
+++ b/lib/accountRevolver.ts
@@ -1,7 +1,7 @@
 import { DriverInterface } from '../drivers/driverInterface.js';
 import { InstrumentedResource, ToolingInterface } from '../drivers/instrumentedResource.js';
 import { RevolverPlugin } from '../plugins/pluginInterface.js';
-import { logger } from './logger.js';
+import { logger, getSubLogger } from './logger.js';
 import path from 'node:path';
 import { promises as fs } from 'node:fs';
 import { buildFilter } from '../plugins/filters/index.js';
@@ -37,10 +37,7 @@ export class AccountRevolver {
 
   constructor(accountConfig: any) {
     this.config = accountConfig;
-    this.logger = logger.getSubLogger(
-      { name: 'accountRevolver' },
-      { accountId: this.config.accountId, accountName: this.config.settings.name },
-    );
+    this.logger = getSubLogger(this.config.settings.name, this.config.accountId);
   }
 
   async initialise(): Promise<void> {

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -91,6 +91,19 @@ function restructureJsonLog(log: any) {
 }
 
 /**
+ * Return a sub-logger with the given accountName and accountId, and any other attributes.
+ * @param accountName - an accountConfig.name
+ * @param accountId - an AWS account ID
+ * @param extra - a object contain other properties to add to the context, eg pluginName, driverName
+ * @returns a child logger based on the settings above
+ */
+export function getSubLogger(accountName: string, accountId: string, extra?: object) {
+  return logger.getSubLogger(
+    { name: `${accountName}(${accountId})` },
+    { accountId: accountId, accountName: accountName, ...extra },
+  );
+}
+/**
  * A Logger that keeps track of whether a log of level 'error' or greater has been emitted.
  */
 export class ErrorTrackingLogger<LogObj> extends Logger<LogObj> {

--- a/lib/objectLog.ts
+++ b/lib/objectLog.ts
@@ -1,5 +1,5 @@
 import { ToolingInterface } from '../drivers/instrumentedResource.js';
-import { logger } from './logger.js';
+import { getSubLogger } from './logger.js';
 import { existsSync, promises as fs } from 'node:fs';
 import { getAwsConfig } from './awsConfig.js';
 import { GetObjectCommand, NoSuchKey, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
@@ -61,12 +61,12 @@ type WriterContext = {
 abstract class AbstractOutputWriter {
   protected readonly options: WriteOptions;
   protected readonly logger;
-  protected readonly context;
+  protected readonly context: WriterContext | undefined;
 
   static filesWritten: string[] = [];
 
   protected constructor(options: WriteOptions, context?: WriterContext) {
-    this.logger = logger;
+    this.logger = getSubLogger(context?.name || 'unknown', context?.accountId || 'unknown');
     this.options = options;
     this.context = context;
   }

--- a/plugins/pluginInterface.ts
+++ b/plugins/pluginInterface.ts
@@ -1,5 +1,5 @@
 import { Logger } from 'tslog';
-import { logger } from '../lib/logger.js';
+import { getSubLogger } from '../lib/logger.js';
 import { ToolingInterface } from '../drivers/instrumentedResource.js';
 
 /**
@@ -18,10 +18,7 @@ export abstract class RevolverPlugin {
     this.accountId = accountConfig.accountId;
     this.pluginConfig = pluginConfig;
     this.pluginConfig.name = pluginName;
-    this.logger = logger.getSubLogger(
-      { name: this.accountConfig.name },
-      { accountId: this.accountId, accountName: this.accountConfig.name, pluginName },
-    );
+    this.logger = getSubLogger(this.accountConfig.name, this.accountId, { pluginName: pluginName });
     this.logger.debug(`Initialising plugin ${this.name} for account ${this.accountConfig.name}`);
   }
 


### PR DESCRIPTION
Per #394 - the rest of the places that use the global logger appear too fine-grained to create a new logger for each.

Note: this PR will change the 'name' for AccountRevolver logging from `accountRevolver` to `${accountName}(${accountId})`