### PR TITLE
Exercise JSON logging

### DIFF
--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -34,7 +34,7 @@ export interface RevolverLogObject {
  * Writes JSON logs to the appropriate console.\{level\} function and converts any configured log prefixes
  * to object keys if they have a ':' separator. Splits out string messages and object messages to message and data.
  */
-function restructureJsonLog(log: any) {
+export function restructureJsonLog(log: any) {
   if (log === undefined) return;
   // biome-ignore lint/suspicious/noGlobalIsNan: we are relying on string-numbers being coerced to numbers
   const positionalEntries: string[] = Object.keys(log).filter((k: any) => !isNaN(k));

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -11,7 +11,7 @@ const logLevels: { [key: string]: number } = {
   fatal: 6,
 };
 
-const logLevelsToConsole: { [key: number]: (...args: any) => any } = {
+export const logLevelsToConsole: { [key: number]: (...args: any) => any } = {
   0: console.trace,
   1: console.trace,
   2: console.debug,

--- a/test/lib/logger.spec.ts
+++ b/test/lib/logger.spec.ts
@@ -1,5 +1,11 @@
 import { expect } from 'chai';
-import { ErrorTrackingLogger, logger, logLevelsToConsole, restructureJsonLog, RevolverLogObject } from '../../lib/logger.js';
+import {
+  ErrorTrackingLogger,
+  logger,
+  logLevelsToConsole,
+  restructureJsonLog,
+  RevolverLogObject,
+} from '../../lib/logger.js';
 
 // TODO: validate JSON format, including restructure
 // TODO: validate metadata
@@ -49,7 +55,7 @@ describe('Validate JSON logging', function () {
   try {
     logLevelsToConsole[2] = (message: any) => {
       debug_messages.push(message);
-    }
+    };
     // emit a debug message
     jsonLogger.debug('sample message 1');
   } finally {

--- a/test/lib/logger.spec.ts
+++ b/test/lib/logger.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { ErrorTrackingLogger, logger, restructureJsonLog, RevolverLogObject } from '../../lib/logger.js';
+import { ErrorTrackingLogger, logger, logLevelsToConsole, restructureJsonLog, RevolverLogObject } from '../../lib/logger.js';
 
 // TODO: validate JSON format, including restructure
 // TODO: validate metadata
@@ -44,7 +44,24 @@ describe('Validate JSON logging', function () {
     },
   });
 
-  // Validate that this works
-  jsonLogger.debug('sample message 1');
-  jsonLogger.info('sample message 2');
+  // redirect console DEBUG messages
+  const debug_messages: any[] = [];
+  try {
+    logLevelsToConsole[2] = (message: any) => {
+      debug_messages.push(message);
+    }
+    // emit a debug message
+    jsonLogger.debug('sample message 1');
+  } finally {
+    // restore console
+    logLevelsToConsole[2] = console.debug;
+  }
+
+  // Validate that the messages were captured
+  expect(debug_messages.length).to.equal(1);
+  const event = JSON.parse(debug_messages[0]);
+  expect(event.message).to.equal('sample message 1');
+  expect(event._meta.logLevelId).to.equal(2);
+  expect(event._meta.logLevelName).to.equal('DEBUG');
+  expect(event._meta.path.fileName).to.equal('logger.spec.ts');
 });

--- a/test/lib/logger.spec.ts
+++ b/test/lib/logger.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { logger } from '../../lib/logger.js';
+import { ErrorTrackingLogger, logger, restructureJsonLog, RevolverLogObject } from '../../lib/logger.js';
 
 // TODO: validate JSON format, including restructure
 // TODO: validate metadata
@@ -27,4 +27,24 @@ describe('Validate ErrorTrackingLogger behaviour', function () {
   expect(logger.hasError).to.be.true;
 
   logger.hasError = false; // reset
+});
+
+describe('Validate JSON logging', function () {
+  const jsonLogger = new ErrorTrackingLogger<RevolverLogObject>({
+    name: 'revolver',
+    type: 'json',
+    // stylePrettyLogs: environ.stylePrettyLogs,
+    // prettyLogTimeZone: environ.prettyLogTimeZone,
+    minLevel: 2, // logLevels['debug'],
+    hideLogPositionForProduction: false, // logLevels[environ.logLevel] > 2,
+    overwrite: {
+      transportJSON: (logObjWithMeta: any) => {
+        restructureJsonLog(logObjWithMeta);
+      },
+    },
+  });
+
+  // Validate that this works
+  jsonLogger.debug('sample message 1');
+  jsonLogger.info('sample message 2');
 });


### PR DESCRIPTION
We had an issue #423 where JSON logging was completely broken, and this was not detected.  Add a simple exercise of the JSON logging type (including exporting restructureJsonLog for access)